### PR TITLE
Fix icat.server integration test setup

### DIFF
--- a/icat-dev-base-hosts.yml
+++ b/icat-dev-base-hosts.yml
@@ -1,19 +1,15 @@
 ---
-
 - hosts: icat-dev-base-hosts
   become: true
   vars_files:
-  - 'group_vars/all/vars.yml'
+    - 'group_vars/all/vars.yml'
   roles:
-  - role: common
-  - role: java
-  - role: mariadb
-  - role: payara
-  - role: authn-simple
-  - role: icat-lucene
-  - role: icat-server
-  - role: authn-db
-  - role: ids-storage_file
-  - role: ids-server
-  - role: topcat
-  - role: dev-common
+    - role: common
+    - role: java
+    - role: mariadb
+    - role: icatdb
+    - role: payara
+    - role: authn-simple
+    - role: authn-db
+    - role: icat-lucene
+    - role: dev-common

--- a/icat-server-dev-hosts.yml
+++ b/icat-server-dev-hosts.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: icat-dev-base-hosts
+- hosts: icat-server-dev-hosts
   become: true
   vars_files:
     - 'group_vars/all/vars.yml'

--- a/roles/authn-db/meta/main.yml
+++ b/roles/authn-db/meta/main.yml
@@ -1,6 +1,5 @@
 ---
-
 dependencies:
   - role: common
   - role: payara
-  - role: icat-server
+  - role: icatdb

--- a/roles/authn-db/tasks/main.yml
+++ b/roles/authn-db/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: 'Check authn-db package'
   stat:
     path: /home/{{ payara_user }}/downloads/authn.db-{{ authn_db_version }}-distro.zip
@@ -36,7 +35,7 @@
     group: '{{ payara_user }}'
     mode: 0664
   notify:
-  - authn-db-handler
+    - authn-db-handler
 
 - name: 'Configure authn-db run.properties'
   copy:
@@ -46,7 +45,7 @@
     group: '{{ payara_user }}'
     mode: 0664
   notify:
-  - authn-db-handler
+    - authn-db-handler
 
 - name: 'Configure authn-db logback.xml'
   copy:
@@ -56,35 +55,14 @@
     group: '{{ payara_user }}'
     mode: 0664
   notify:
-  - authn-db-handler
+    - authn-db-handler
 
 - name: 'Setup authn-db if not setup'
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.authn_db is not defined) or (ansible_local.local.instantiations.authn_db != 'true')
 
-- name: 'Configure icat server run.properties to enable db mnemonic'
-  lineinfile:
-    path: /home/{{ payara_user }}/install/icat.server/run.properties
-    line: 'authn.list = simple db'
-    regexp: '^authn\.list = (.+)$'
-  notify:
-  - icat-server-handler
-
-- name: 'Configure icat server run.properties to set authn db url'
-  lineinfile:
-    path: /home/{{ payara_user }}/install/icat.server/run.properties
-    line: 'authn.db.url = https://{{ authn_db_url }}:8181'
-    regexp: '^!?authn\.db\.url = (.+)$'
-  notify:
-  - icat-server-handler
-
-- name: 'Configure icat server run.properties to add db/root to rootUserNames'
-  lineinfile:
-    path: /home/{{ payara_user }}/install/icat.server/run.properties
-    line: 'rootUserNames = simple/root db/root'
-    regexp: '^rootUserNames = (.+)$'
-  notify:
-  - icat-server-handler
+- name: 'Create PASSWD table if it doesnt exist'
+  command: mysql --user={{ db_icat_username }} --password={{ db_icat_password }} -e "create table IF NOT EXISTS PASSWD (UserName VARCHAR(20), encodedPassword VARCHAR(20));" {{ icat_database }}
 
 - name: 'Check if "notroot" user is already in database'
   command: mysql --user={{ db_icat_username }} --password={{ db_icat_password }} -e "SELECT USERNAME FROM PASSWD WHERE USERNAME='notroot'" {{ icat_database }}

--- a/roles/icat-server/meta/main.yml
+++ b/roles/icat-server/meta/main.yml
@@ -1,7 +1,7 @@
 ---
-
 dependencies:
   - role: mariadb
+  - role: icatdb
   - role: payara
   - role: authn-simple
   - role: icat-lucene

--- a/roles/icat-server/tasks/main.yml
+++ b/roles/icat-server/tasks/main.yml
@@ -1,39 +1,9 @@
 ---
-
 - name: 'Install common icat-server dependencies'
   package: name={{ item }} state=present
   with_items:
-  - python-suds
-  - python-requests
-
-- name: 'Install icat-server dependencies for Red Hat systems'
-  package: name={{ item }} state=present
-  with_items:
-  - MySQL-python
-  - mysql-connector-java
-  when: ansible_os_family == 'RedHat'
-
-- name: 'Install icat-server packages for Debian systems'
-  package: name={{ item }} state=present
-  with_items:
-  - python-mysqldb
-  - libmysql-java
-  when: ansible_os_family == 'Debian'
-
-- name: 'Check payara domain'
-  stat:
-    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext
-  register: domainResult
-
-- name: 'Create symlink to mysql connector library'
-  file:
-    src: /usr/share/java/mysql-connector-java.jar
-    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext/mysql-connector-java.jar
-    state: link
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
-  when: domainResult.stat.exists is defined and domainResult.stat.exists == true
-  notify: payara-handler
+    - python-suds
+    - python-requests
 
 - name: 'Check icat-server package'
   stat:
@@ -117,7 +87,7 @@
     group: '{{ payara_user }}'
     mode: 0600
   notify:
-  - icat-server-handler
+    - icat-server-handler
 
 - name: 'Configure icat-server run.properties'
   template:
@@ -127,7 +97,7 @@
     group: '{{ payara_user }}'
     mode: 0664
   notify:
-  - icat-server-handler
+    - icat-server-handler
 
 - name: 'Configure icat-server logback.xml'
   copy:
@@ -137,7 +107,7 @@
     group: '{{ payara_user }}'
     mode: 0664
   notify:
-  - icat-server-handler
+    - icat-server-handler
 
 - name: 'Create database for icat-server'
   mysql_db:

--- a/roles/icat-server/tasks/main.yml
+++ b/roles/icat-server/tasks/main.yml
@@ -109,20 +109,6 @@
   notify:
     - icat-server-handler
 
-- name: 'Create database for icat-server'
-  mysql_db:
-    name: '{{ icat_database }}'
-    login_user: '{{ db_root_username }}'
-    login_password: '{{ db_root_password }}'
-
-- name: 'Create user for icat-server database'
-  mysql_user:
-    name: '{{ db_icat_username }}'
-    password: '{{ db_icat_password }}'
-    priv: '{{ icat_database }}.*:ALL,GRANT'
-    login_user: '{{ db_root_username }}'
-    login_password: '{{ db_root_password }}'
-
 - name: 'Setup icat-server if not setup'
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.icat_server is not defined) or (ansible_local.local.instantiations.icat_server != 'true')

--- a/roles/icatdb/meta/main.yml
+++ b/roles/icatdb/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: mariadb

--- a/roles/icatdb/tasks/main.yml
+++ b/roles/icatdb/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: 'Create database for icat-server'
+  mysql_db:
+    name: '{{ icat_database }}'
+    login_user: '{{ db_root_username }}'
+    login_password: '{{ db_root_password }}'
+
+- name: 'Create user for icat-server database'
+  mysql_user:
+    name: '{{ db_icat_username }}'
+    password: '{{ db_icat_password }}'
+    priv: '{{ icat_database }}.*:ALL,GRANT'
+    login_user: '{{ db_root_username }}'
+    login_password: '{{ db_root_password }}'

--- a/roles/ids-server/meta/main.yml
+++ b/roles/ids-server/meta/main.yml
@@ -1,7 +1,7 @@
 ---
-
 dependencies:
   - role: common
+  - role: icatdb
   - role: payara
   - role: icat-server
   - role: ids-storage_file

--- a/roles/mariadb/vars/debian.yml
+++ b/roles/mariadb/vars/debian.yml
@@ -1,7 +1,8 @@
 ---
-
 mariadb_daemon: mysql
 mariadb_config_dir: /etc/mysql/conf.d
 mariadb_pkgs:
-- mariadb-server
-- mariadb-client
+  - mariadb-server
+  - mariadb-client
+  - python-mysqldb
+  - libmysql-java

--- a/roles/mariadb/vars/redhat.yml
+++ b/roles/mariadb/vars/redhat.yml
@@ -1,7 +1,8 @@
 ---
-
 mariadb_daemon: mariadb
 mariadb_config_dir: /etc/my.cnf.d
 mariadb_pkgs:
-- mariadb-server
-- mariadb
+  - mariadb-server
+  - mariadb
+  - MySQL-python
+  - mysql-connector-java

--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: 'Create payara user group'
   group:
     name: '{{ payara_user }}'
@@ -51,7 +50,7 @@
     owner: root
     group: root
     mode: 0775
-     
+
 - name: 'Check if .bash_profile exists'
   stat:
     path: /home/{{ payara_user }}/.bash_profile
@@ -146,3 +145,18 @@
 - name: 'Setup payara if not setup'
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.payara is not defined) or (ansible_local.local.instantiations.payara != 'true')
+
+- name: 'Check payara domain'
+  stat:
+    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext
+  register: domainResult
+
+- name: 'Create symlink to mysql connector library'
+  file:
+    src: /usr/share/java/mysql-connector-java.jar
+    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext/mysql-connector-java.jar
+    state: link
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
+  when: domainResult.stat.exists is defined and domainResult.stat.exists == true
+  notify: payara-handler

--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -160,3 +160,5 @@
     group: '{{ payara_user }}'
   when: domainResult.stat.exists is defined and domainResult.stat.exists == true
   notify: payara-handler
+
+- meta: flush_handlers


### PR DESCRIPTION
Closes #4
Related to icatproject/icat.server#205

Since the problem with database schema upgrades is with installing a previous version of `icat.server` before building a new version, instead allow for `icat-server` task not to be ran. This required some refactoring to allow for `authn-db` to create the password table itself, and moving tasks that happened in `icat-server` to other tasks.