### PR TITLE
Adding authenticator role to playbook sets up authenticator config correctly

### DIFF
--- a/icat-test-hosts.yml
+++ b/icat-test-hosts.yml
@@ -1,17 +1,17 @@
 ---
-
 - hosts: icat-test-hosts
   become: true
   vars_files:
-  - 'group_vars/all/vars.yml'
+    - 'group_vars/all/vars.yml'
   roles:
-  - role: common
-  - role: java
-  - role: mariadb
-  - role: payara
-  - role: authn-simple
-  - role: icat-lucene
-  - role: icat-server
-  - role: ids-storage_file
-  - role: ids-server
-  - role: topcat
+    - role: common
+    - role: java
+    - role: mariadb
+    - role: icatdb
+    - role: payara
+    - role: authn-simple
+    - role: icat-lucene
+    - role: icat-server
+    - role: ids-storage_file
+    - role: ids-server
+    - role: topcat

--- a/roles/authn-db/tasks/installation.yml
+++ b/roles/authn-db/tasks/installation.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: 'Setup authn-db'
   import_tasks: handlers/authn-db-handler.yml
 
@@ -9,5 +8,14 @@
     section: 'instantiations'
     option: 'authn_db'
     value: 'true'
+    no_extra_spaces: true
+    create: false
+
+- name: 'Set fact on host to record version of authn-db that has been instantiated'
+  ini_file:
+    path: /etc/ansible/facts.d/local.fact
+    section: 'versions'
+    option: 'authn_db'
+    value: '{{ authn_db_version }}'
     no_extra_spaces: true
     create: false

--- a/roles/authn-db/tasks/main.yml
+++ b/roles/authn-db/tasks/main.yml
@@ -61,6 +61,10 @@
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.authn_db is not defined) or (ansible_local.local.instantiations.authn_db != 'true')
 
+- name: 'Set temporary fact to indicate authn_db is installed within play'
+  set_fact:
+    authn_db: true
+
 - name: 'Create PASSWD table if it doesnt exist'
   command: mysql --user={{ db_icat_username }} --password={{ db_icat_password }} -e "create table IF NOT EXISTS PASSWD (UserName VARCHAR(20), encodedPassword VARCHAR(20));" {{ icat_database }}
 

--- a/roles/authn-simple/tasks/main.yml
+++ b/roles/authn-simple/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: 'Check authn-simple package'
   stat:
     path: /home/{{ payara_user }}/downloads/authn.simple-{{ authn_simple_version }}-distro.zip
@@ -36,7 +35,7 @@
     group: '{{ payara_user }}'
     mode: 0600
   notify:
-  - authn-simple-handler
+    - authn-simple-handler
 
 - name: 'Configure authn-simple run.properties'
   template:
@@ -46,7 +45,7 @@
     group: '{{ payara_user }}'
     mode: 0664
   notify:
-  - authn-simple-handler
+    - authn-simple-handler
 
 - name: 'Configure authn-simple logback.xml'
   copy:
@@ -56,8 +55,12 @@
     group: '{{ payara_user }}'
     mode: 0664
   notify:
-  - authn-simple-handler
+    - authn-simple-handler
 
 - name: 'Setup authn-simple if not setup'
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.authn_simple is not defined) or (ansible_local.local.instantiations.authn_simple != 'true')
+
+- name: 'Set temporary fact to indicate authn_simple is installed within play'
+  set_fact:
+    authn_simple: true

--- a/roles/icat-server/tasks/main.yml
+++ b/roles/icat-server/tasks/main.yml
@@ -62,10 +62,6 @@
     group: '{{ payara_user }}'
     mode: 0775
 
-- name: 'Force ansible to regather local facts - needed to detect what authn plugins have been installed'
-  setup:
-    filter: ansible_local
-
 - name: 'Copy over payara setup.properties'
   template:
     src: roles/payara/templates/setup.properties.j2

--- a/roles/icat-server/tasks/main.yml
+++ b/roles/icat-server/tasks/main.yml
@@ -62,6 +62,10 @@
     group: '{{ payara_user }}'
     mode: 0775
 
+- name: 'Force ansible to regather local facts - needed to detect what authn plugins have been installed'
+  setup:
+    filter: ansible_local
+
 - name: 'Copy over payara setup.properties'
   template:
     src: roles/payara/templates/setup.properties.j2

--- a/roles/icat-server/templates/run.properties.j2
+++ b/roles/icat-server/templates/run.properties.j2
@@ -5,7 +5,7 @@
 lifetimeMinutes = 120
 
 # Provide CRUD access to authz tables
-rootUserNames = simple/root
+rootUserNames = {% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple/root {% endif %}{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db/root {% endif %}
 
 # Restrict total number of entities to return in a search call
 maxEntities = 10000
@@ -20,20 +20,41 @@ importCacheSize = 50
 exportCacheSize = 50
 
 # Desired authentication plugin mnemonics
-authn.list = simple
+authn.list = {% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple {% endif %}{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db {% endif %}{% if ansible_local['local']['instantiations']['authn_anon'] == 'true' %}anon {% endif %}{% if ansible_local['local']['instantiations']['authn_ldap'] == 'true' %}ldap {% endif %}
 
 # Parameters for each of the four plugins
+{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}
+authn.db.url = https://{{ authn_db_url }}:8181
+{% else %}
 !authn.db.url = https://localhost:8181
+{% endif %}
 
+{% if ansible_local['local']['instantiations']['authn_ldap'] == 'true' %}
+authn.ldap.url = https://{{authn_ldap_url}}:8181
+authn.ldap.admin = true
+authn.ldap.friendly = Federal Id
+{% else %}
 !authn.ldap.url = https://localhost:8181
 !authn.ldap.admin = true
 !authn.ldap.friendly = Federal Id
+{% endif %}
 
+{% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}
 authn.simple.url = https://{{ authn_simple_url }}:8181 
 authn.simple.friendly = Simple
+{% else %}
+!authn.simple.url = https://localhost:8181 
+!authn.simple.friendly = Simple
+{% endif %}
 
+
+{% if ansible_local['local']['instantiations']['authn_anon'] == 'true' %}
+authn.anon.url = https://{{authn_anon_url}}:8181
+authn.anon.friendly = Anonymous
+{% else %}
 !authn.anon.url = https://localhost:8181
 !authn.anon.friendly = Anonymous
+{% endif %}
 
 # Notification setup
 notification.list = Dataset Datafile

--- a/roles/icat-server/templates/run.properties.j2
+++ b/roles/icat-server/templates/run.properties.j2
@@ -5,7 +5,7 @@
 lifetimeMinutes = 120
 
 # Provide CRUD access to authz tables
-rootUserNames = {% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple/root {% endif %}{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db/root {% endif %}
+rootUserNames = {% if authn_simple is defined and authn_simple %}simple/root {% endif %}{% if authn_db is defined and authn_db %}db/root {% endif %}
 
 # Restrict total number of entities to return in a search call
 maxEntities = 10000
@@ -20,17 +20,17 @@ importCacheSize = 50
 exportCacheSize = 50
 
 # Desired authentication plugin mnemonics
-authn.list = {% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple {% endif %}{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db {% endif %}{% if ansible_local['local']['instantiations']['authn_anon'] == 'true' %}anon {% endif %}{% if ansible_local['local']['instantiations']['authn_ldap'] == 'true' %}ldap {% endif %}
+authn.list = {% if authn_simple is defined and authn_simple %}simple {% endif %}{% if authn_db is defined and authn_db %}db {% endif %}{% if authn_anon is defined and authn_anon %}anon {% endif %}{% if authn_ldap is defined and authn_ldap %}ldap {% endif %}
 
 # Parameters for each of the four plugins
-{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}
-authn.db.url = https://{{ authn_db_url }}:8181
+{% if authn_db is defined and authn_db %}
+authn.db.url = https://{{ authn_db is defined and authn_db_url }}:8181
 {% else %}
 !authn.db.url = https://localhost:8181
 {% endif %}
 
-{% if ansible_local['local']['instantiations']['authn_ldap'] == 'true' %}
-authn.ldap.url = https://{{authn_ldap_url}}:8181
+{% if authn_ldap is defined and authn_ldap %}
+authn.ldap.url = https://{{authn_ldap is defined and authn_ldap_url}}:8181
 authn.ldap.admin = true
 authn.ldap.friendly = Federal Id
 {% else %}
@@ -39,17 +39,16 @@ authn.ldap.friendly = Federal Id
 !authn.ldap.friendly = Federal Id
 {% endif %}
 
-{% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}
-authn.simple.url = https://{{ authn_simple_url }}:8181 
+{% if authn_simple is defined and authn_simple %}
+authn.simple.url = https://{{ authn_simple is defined and authn_simple_url }}:8181 
 authn.simple.friendly = Simple
 {% else %}
 !authn.simple.url = https://localhost:8181 
 !authn.simple.friendly = Simple
 {% endif %}
 
-
-{% if ansible_local['local']['instantiations']['authn_anon'] == 'true' %}
-authn.anon.url = https://{{authn_anon_url}}:8181
+{% if authn_anon is defined and authn_anon %}
+authn.anon.url = https://{{authn_anon is defined and authn_anon_url}}:8181
 authn.anon.friendly = Anonymous
 {% else %}
 !authn.anon.url = https://localhost:8181

--- a/roles/icat-server/templates/run.properties.j2
+++ b/roles/icat-server/templates/run.properties.j2
@@ -24,13 +24,13 @@ authn.list = {% if authn_simple is defined and authn_simple %}simple {% endif %}
 
 # Parameters for each of the four plugins
 {% if authn_db is defined and authn_db %}
-authn.db.url = https://{{ authn_db is defined and authn_db_url }}:8181
+authn.db.url = https://{{ authn_db_url }}:8181
 {% else %}
 !authn.db.url = https://localhost:8181
 {% endif %}
 
 {% if authn_ldap is defined and authn_ldap %}
-authn.ldap.url = https://{{authn_ldap is defined and authn_ldap_url}}:8181
+authn.ldap.url = https://{{ authn_ldap_url }}:8181
 authn.ldap.admin = true
 authn.ldap.friendly = Federal Id
 {% else %}
@@ -40,7 +40,7 @@ authn.ldap.friendly = Federal Id
 {% endif %}
 
 {% if authn_simple is defined and authn_simple %}
-authn.simple.url = https://{{ authn_simple is defined and authn_simple_url }}:8181 
+authn.simple.url = https://{{ authn_simple_url }}:8181 
 authn.simple.friendly = Simple
 {% else %}
 !authn.simple.url = https://localhost:8181 
@@ -48,7 +48,7 @@ authn.simple.friendly = Simple
 {% endif %}
 
 {% if authn_anon is defined and authn_anon %}
-authn.anon.url = https://{{authn_anon is defined and authn_anon_url}}:8181
+authn.anon.url = https://{{ authn_anon_url }}:8181
 authn.anon.friendly = Anonymous
 {% else %}
 !authn.anon.url = https://localhost:8181

--- a/roles/ids-server/templates/run.properties.j2
+++ b/roles/ids-server/templates/run.properties.j2
@@ -9,9 +9,9 @@ plugin.main.dir = /home/{{ payara_user }}/data/main
 cache.dir = /home/{{ payara_user }}/data/cache
 preparedCount = 10000
 processQueueIntervalSeconds = 5
-rootUserNames = simple/root db/root
+rootUserNames = {% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple/root {% endif %}{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db/root {% endif %}
 sizeCheckIntervalSeconds = 60
-reader = simple username {{ authn_reader_username }} password {{ authn_reader_password }}
+reader = {% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db username root password password{% elif ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple username {{ authn_reader_username }} password {{ authn_reader_password }}{% endif %}
 !readOnly = true
 maxIdsInQuery = 1000
 

--- a/roles/ids-server/templates/run.properties.j2
+++ b/roles/ids-server/templates/run.properties.j2
@@ -9,11 +9,13 @@ plugin.main.dir = /home/{{ payara_user }}/data/main
 cache.dir = /home/{{ payara_user }}/data/cache
 preparedCount = 10000
 processQueueIntervalSeconds = 5
-rootUserNames = {% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple/root {% endif %}{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db/root {% endif %}
 sizeCheckIntervalSeconds = 60
-reader = {% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db username root password password{% elif ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple username {{ authn_reader_username }} password {{ authn_reader_password }}{% endif %}
 !readOnly = true
 maxIdsInQuery = 1000
+rootUserNames = {% if authn_simple is defined and authn_simple %}simple/root {% endif %}{% if authn_db is defined and authn_db %}db/root {% endif %}
+
+reader = {% if authn_db is defined and authn_db %}db username root password password{% elif authn_simple is defined and authn_simple %}simple username {{ authn_reader_username }} password {{ authn_reader_password }}{% else %}{% endif %}
+
 
 # Properties for archive storage
 plugin.archive.class = org.icatproject.ids.storage.ArchiveFileStorage

--- a/roles/topcat/tasks/create-topcat-json.yml
+++ b/roles/topcat/tasks/create-topcat-json.yml
@@ -23,6 +23,22 @@
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
+- name: 'Delete DLS facility in topcat.json'
+  shell: cat topcat.json | jq 'del(.facilities[1])' > tmp.json && mv tmp.json topcat.json
+  become: true
+  become_user: '{{ payara_user }}'
+  args:
+    chdir: /home/{{ payara_user }}/install/topcat
+    executable: /bin/bash
+
+- name: 'Delete ISIS facility in topcat.json'
+  shell: cat topcat.json | jq 'del(.facilities[1])' > tmp.json && mv tmp.json topcat.json
+  become: true
+  become_user: '{{ payara_user }}'
+  args:
+    chdir: /home/{{ payara_user }}/install/topcat
+    executable: /bin/bash
+
 - name: 'Set authenticationTypes to [] in LILS facility in topcat.json'
   shell: cat topcat.json | jq '.facilities[0].authenticationTypes = []' > tmp.json && mv tmp.json topcat.json
   become: true

--- a/roles/topcat/tasks/create-topcat-json.yml
+++ b/roles/topcat/tasks/create-topcat-json.yml
@@ -8,7 +8,7 @@
     executable: /bin/bash
 
 - name: 'Remove all facilities except LILS (the test facility)'
-  shell: cat topcat.json | jq '{site, facilities: [ .facilities[] | select(.name == "LILS") ], plugins}' > tmp.json && mv tmp.json topcat.json
+  shell: 'cat topcat.json | jq ''{site, facilities: [ .facilities[] | select(.name == "LILS") ], plugins}'' > tmp.json && mv tmp.json topcat.json'
   become: true
   become_user: '{{ payara_user }}'
   args:

--- a/roles/topcat/tasks/create-topcat-json.yml
+++ b/roles/topcat/tasks/create-topcat-json.yml
@@ -1,111 +1,108 @@
 ---
-- name: 'Create topcat.json part 1'
-  shell: jq '.site.topcatUrl = \"https://{{ topcat_url }}:8181\"' > topcat-intermediate1.json
+- name: 'Edit topcatURL in topcat.json'
+  shell: cat topcat.json.example | jq '.site.topcatUrl = "https://{{ topcat_url }}:8181"' > tmp.json && mv tmp.json topcat.json
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
-- name: 'Create topcat.json part 2'
-  shell: cat topcat-intermediate1.json | jq '.facilities[0].idsUrl = \"https://{{ ids_url }}:8181\"' > topcat-intermediate2.json
+- name: 'Edit idsUrl in topcat.json'
+  shell: cat topcat.json | jq '.facilities[0].idsUrl = "https://{{ ids_url }}:8181"' > tmp.json && mv tmp.json topcat.json
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
-- name: 'Create topcat.json part 3'
-  shell: cat topcat-intermediate2.json | jq '.facilities[0].icatUrl = \"https://{{ icat_url }}:8181\"' > topcat-intermediate3.json
+- name: 'Edit icatUrl in topcat.json'
+  shell: cat topcat.json | jq '.facilities[0].icatUrl = "https://{{ icat_url }}:8181"' > tmp.json && mv tmp.json topcat.json
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
-- name: 'Create topcat.json part 4'
-  shell: cat topcat-intermediate3.json | jq '.facilities[0].authenticationTypes = []' > topcat-intermediate4.json
+- name: 'Set authenticationTypes to [] in LILS facility in topcat.json'
+  shell: cat topcat.json | jq '.facilities[0].authenticationTypes = []' > tmp.json && mv tmp.json topcat.json
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
-- name: 'Add Simple authn to topcat.json part 4'
-  shell: 'cat topcat-intermediate4.json | jq ''.facilities[0].authenticationTypes += [{"title": "Simple", "plugin": "simple"}]'' > topcat-intermediate4.json'
+- name: 'Add Simple authn in topcat.json'
+  shell: 'cat topcat.json | jq ''.facilities[0].authenticationTypes += [{"title": "Simple", "plugin": "simple"}]'' > tmp.json && mv tmp.json topcat.json'
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
-  when: ansible_local.local.instantiations.authn_simple == 'true'
+  when: authn_simple is defined and authn_simple
 
-- name: 'Add DB authn to topcat.json part 4'
-  shell: 'cat topcat-intermediate4.json | jq ''.facilities[0].authenticationTypes += [{"title": "DB", "plugin": "db"}]'' > topcat-intermediate4.json'
+- name: 'Add DB authn in topcat.json'
+  shell: 'cat topcat.json | jq ''.facilities[0].authenticationTypes += [{"title": "DB", "plugin": "db"}]'' > tmp.json && mv tmp.json topcat.json'
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
-  when: ansible_local.local.instantiations.authn_db == 'true'
+  when: authn_db is defined and authn_db
 
-- name: 'Add Anon authn to topcat.json part 4'
-  shell: 'cat topcat-intermediate4.json | jq ''.facilities[0].authenticationTypes += [{"title": "Anonymous", "plugin": "anon"}]'' > topcat-intermediate4.json'
+- name: 'Add Anon authn in topcat.json'
+  shell: 'cat topcat.json | jq ''.facilities[0].authenticationTypes += [{"title": "Anonymous", "plugin": "anon"}]'' > tmp.json && mv tmp.json topcat.json'
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
-  when: ansible_local.local.instantiations.authn_anon == 'true'
+  when: authn_anon is defined and authn_anon
 
-- name: 'Add LDAP authn to topcat.json part 4'
-  shell: 'cat topcat-intermediate4.json | jq ''.facilities[0].authenticationTypes += [{"title": "LDAP", "plugin": "ldap"}]'' > topcat-intermediate4.json'
+- name: 'Add LDAP authn in topcat.json'
+  shell: 'cat topcat.json | jq ''.facilities[0].authenticationTypes += [{"title": "LDAP", "plugin": "ldap"}]'' > tmp.json && mv tmp.json topcat.json'
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
-  when: ansible_local.local.instantiations.authn_ldap == 'true'
+  when: authn_ldap is defined and authn_ldap
 
-- name: 'Create topcat.json part 5'
-  shell: cat topcat-intermediate4.json | jq '.facilities[0].downloadTransportTypes[0].type = "http"' > topcat-intermediate5.json
+- name: 'Set http transport type in topcat.json'
+  shell: cat topcat.json | jq '.facilities[0].downloadTransportTypes[0].type = "http"' > tmp.json && mv tmp.json topcat.json
   become: true
-  become_user: glassfish
-  args:
-    chdir: /home/{{ payara_user }}/install/topcat
-    executable: /bin/bash
-
-- name: 'Create topcat.json part 6'
-  shell: cat topcat-intermediate5.json | jq '.facilities[0].downloadTransportTypes[0].idsUrl = "http://{{ ids_url }}:8080"' > topcat-intermediate6.json
-  become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
-- name: 'Create topcat.json part 7'
-  shell: cat topcat-intermediate6.json | jq '.facilities[0].downloadTransportTypes[1].type = "https"' > topcat-intermediate7.json
+- name: 'Edit http download idsUrl in topcat.json'
+  shell: cat topcat.json | jq '.facilities[0].downloadTransportTypes[0].idsUrl = "http://{{ ids_url }}:8080"' > tmp.json && mv tmp.json topcat.json
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
-- name: 'Create topcat.json part 8'
-  shell: cat topcat-intermediate7.json | jq '.facilities[0].downloadTransportTypes[1].idsUrl = "https://{{ ids_url }}:8181"' > topcat.json
+- name: 'Set https transport type in topcat.json'
+  shell: cat topcat.json | jq '.facilities[0].downloadTransportTypes[1].type = "https"' > tmp.json && mv tmp.json topcat.json
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
-- name: 'Remove intermediate files'
-  shell: rm topcat-intermediate*
+- name: 'Edit https download idsUrl in topcat.json'
+  shell: cat topcat.json | jq '.facilities[0].downloadTransportTypes[1].idsUrl = "https://{{ ids_url }}:8181"' > tmp.json && mv tmp.json topcat.json
   become: true
-  become_user: glassfish
+  become_user: '{{ payara_user }}'
   args:
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
+
+- name: 'Remove intermediate file'
+  file:
+    path: /home/{{ payara_user }}/install/topcat/tmp.json
+    state: absent
 
 - name: 'Set mode of topcat.json'
   file:

--- a/roles/topcat/tasks/create-topcat-json.yml
+++ b/roles/topcat/tasks/create-topcat-json.yml
@@ -1,66 +1,110 @@
 ---
-
 - name: 'Create topcat.json part 1'
-  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat.json.example | jq '.site.topcatUrl = \"https://{{ topcat_url }}:8181\"' > topcat-intermediate1.json"
+  shell: jq '.site.topcatUrl = \"https://{{ topcat_url }}:8181\"' > topcat-intermediate1.json
   become: true
-  become_user: root
+  become_user: glassfish
   args:
+    chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
 - name: 'Create topcat.json part 2'
-  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate1.json | jq '.facilities[0].idsUrl = \"https://{{ ids_url }}:8181\"' > topcat-intermediate2.json"
+  shell: cat topcat-intermediate1.json | jq '.facilities[0].idsUrl = \"https://{{ ids_url }}:8181\"' > topcat-intermediate2.json
   become: true
-  become_user: root
+  become_user: glassfish
   args:
+    chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
 - name: 'Create topcat.json part 3'
-  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate2.json | jq '.facilities[0].icatUrl = \"https://{{ icat_url }}:8181\"' > topcat-intermediate3.json"
+  shell: cat topcat-intermediate2.json | jq '.facilities[0].icatUrl = \"https://{{ icat_url }}:8181\"' > topcat-intermediate3.json
   become: true
-  become_user: root
+  become_user: glassfish
   args:
+    chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
 - name: 'Create topcat.json part 4'
-  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate3.json | jq 'del(.facilities[0].authenticationTypes[1])' > topcat-intermediate4.json"
+  shell: cat topcat-intermediate3.json | jq '.facilities[0].authenticationTypes = []' > topcat-intermediate4.json
   become: true
-  become_user: root
+  become_user: glassfish
   args:
+    chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
-- name: 'Create topcat.json part 5'
-  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate4.json | jq '.facilities[0].downloadTransportTypes[0].type = \"http\"' > topcat-intermediate5.json"
+- name: 'Add Simple authn to topcat.json part 4'
+  shell: 'cat topcat-intermediate4.json | jq ''.facilities[0].authenticationTypes += [{"title": "Simple", "plugin": "simple"}]'' > topcat-intermediate4.json'
   become: true
-  become_user: root
+  become_user: glassfish
   args:
+    chdir: /home/{{ payara_user }}/install/topcat
+    executable: /bin/bash
+  when: ansible_local.local.instantiations.authn_simple == 'true'
+
+- name: 'Add DB authn to topcat.json part 4'
+  shell: 'cat topcat-intermediate4.json | jq ''.facilities[0].authenticationTypes += [{"title": "DB", "plugin": "db"}]'' > topcat-intermediate4.json'
+  become: true
+  become_user: glassfish
+  args:
+    chdir: /home/{{ payara_user }}/install/topcat
+    executable: /bin/bash
+  when: ansible_local.local.instantiations.authn_db == 'true'
+
+- name: 'Add Anon authn to topcat.json part 4'
+  shell: 'cat topcat-intermediate4.json | jq ''.facilities[0].authenticationTypes += [{"title": "Anonymous", "plugin": "anon"}]'' > topcat-intermediate4.json'
+  become: true
+  become_user: glassfish
+  args:
+    chdir: /home/{{ payara_user }}/install/topcat
+    executable: /bin/bash
+  when: ansible_local.local.instantiations.authn_anon == 'true'
+
+- name: 'Add LDAP authn to topcat.json part 4'
+  shell: 'cat topcat-intermediate4.json | jq ''.facilities[0].authenticationTypes += [{"title": "LDAP", "plugin": "ldap"}]'' > topcat-intermediate4.json'
+  become: true
+  become_user: glassfish
+  args:
+    chdir: /home/{{ payara_user }}/install/topcat
+    executable: /bin/bash
+  when: ansible_local.local.instantiations.authn_ldap == 'true'
+
+- name: 'Create topcat.json part 5'
+  shell: cat topcat-intermediate4.json | jq '.facilities[0].downloadTransportTypes[0].type = "http"' > topcat-intermediate5.json
+  become: true
+  become_user: glassfish
+  args:
+    chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
 - name: 'Create topcat.json part 6'
-  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate5.json | jq '.facilities[0].downloadTransportTypes[0].idsUrl = \"http://{{ ids_url }}:8080\"' > topcat-intermediate6.json"
+  shell: cat topcat-intermediate5.json | jq '.facilities[0].downloadTransportTypes[0].idsUrl = "http://{{ ids_url }}:8080"' > topcat-intermediate6.json
   become: true
-  become_user: root
+  become_user: glassfish
   args:
+    chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
 - name: 'Create topcat.json part 7'
-  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate6.json | jq '.facilities[0].downloadTransportTypes[1].type = \"https\"' > topcat-intermediate7.json"
+  shell: cat topcat-intermediate6.json | jq '.facilities[0].downloadTransportTypes[1].type = "https"' > topcat-intermediate7.json
   become: true
-  become_user: root
+  become_user: glassfish
   args:
+    chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
 - name: 'Create topcat.json part 8'
-  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate7.json | jq '.facilities[0].downloadTransportTypes[1].idsUrl = \"https://{{ ids_url }}:8181\"' > topcat.json"
+  shell: cat topcat-intermediate7.json | jq '.facilities[0].downloadTransportTypes[1].idsUrl = "https://{{ ids_url }}:8181"' > topcat.json
   become: true
-  become_user: root
+  become_user: glassfish
   args:
+    chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
 - name: 'Remove intermediate files'
-  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; rm topcat-intermediate*"'
+  shell: rm topcat-intermediate*
   become: true
-  become_user: root
+  become_user: glassfish
   args:
+    chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
 - name: 'Set mode of topcat.json'

--- a/roles/topcat/tasks/create-topcat-json.yml
+++ b/roles/topcat/tasks/create-topcat-json.yml
@@ -7,6 +7,14 @@
     chdir: /home/{{ payara_user }}/install/topcat
     executable: /bin/bash
 
+- name: 'Remove all facilities except LILS (the test facility)'
+  shell: cat topcat.json | jq '{site, facilities: [ .facilities[] | select(.name == "LILS") ], plugins}' > tmp.json && mv tmp.json topcat.json
+  become: true
+  become_user: '{{ payara_user }}'
+  args:
+    chdir: /home/{{ payara_user }}/install/topcat
+    executable: /bin/bash
+
 - name: 'Edit idsUrl in topcat.json'
   shell: cat topcat.json | jq '.facilities[0].idsUrl = "https://{{ ids_url }}:8181"' > tmp.json && mv tmp.json topcat.json
   become: true
@@ -17,22 +25,6 @@
 
 - name: 'Edit icatUrl in topcat.json'
   shell: cat topcat.json | jq '.facilities[0].icatUrl = "https://{{ icat_url }}:8181"' > tmp.json && mv tmp.json topcat.json
-  become: true
-  become_user: '{{ payara_user }}'
-  args:
-    chdir: /home/{{ payara_user }}/install/topcat
-    executable: /bin/bash
-
-- name: 'Delete DLS facility in topcat.json'
-  shell: cat topcat.json | jq 'del(.facilities[1])' > tmp.json && mv tmp.json topcat.json
-  become: true
-  become_user: '{{ payara_user }}'
-  args:
-    chdir: /home/{{ payara_user }}/install/topcat
-    executable: /bin/bash
-
-- name: 'Delete ISIS facility in topcat.json'
-  shell: cat topcat.json | jq 'del(.facilities[1])' > tmp.json && mv tmp.json topcat.json
   become: true
   become_user: '{{ payara_user }}'
   args:

--- a/roles/topcat/templates/topcat.properties.j2
+++ b/roles/topcat/templates/topcat.properties.j2
@@ -57,7 +57,7 @@ poll.delay = 600
 poll.interval.wait = 600
 
 # A list of usernames that can use the admin REST API and Topcat admin user interface
-adminUserNames = simple/root db/root
+adminUserNames = {% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple/root {% endif %}{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db/root {% endif %}
 
 # The maximum number objects that can be cached before pruning will take place
 maxCacheSize = 100000

--- a/roles/topcat/templates/topcat.properties.j2
+++ b/roles/topcat/templates/topcat.properties.j2
@@ -57,7 +57,7 @@ poll.delay = 600
 poll.interval.wait = 600
 
 # A list of usernames that can use the admin REST API and Topcat admin user interface
-adminUserNames = {% if ansible_local['local']['instantiations']['authn_simple'] == 'true' %}simple/root {% endif %}{% if ansible_local['local']['instantiations']['authn_db'] == 'true' %}db/root {% endif %}
+adminUserNames = {% if authn_simple is defined and authn_simple %}simple/root {% endif %}{% if authn_db is defined and authn_db %}db/root {% endif %}
 
 # The maximum number objects that can be cached before pruning will take place
 maxCacheSize = 100000


### PR DESCRIPTION
Previously, the `icat-server`, `ids-server` and `topcat` roles did not change their configuration based on which auth plugins were installed. Now, a fact is set and this fact is checked when templating files in those roles. Future proofed by checking `authn_ldap` and `authn_anon` for if those roles are ever created in the future.

Additionally, `authn_db` wasn't setting its version and a fix for #7.