### PR TITLE
Add authn.anon role

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -1,51 +1,53 @@
 ---
-
 # Payara user and admin user's password
-payara_user: 'glassfish'
-payara_admin_password: '{{ vault_payara_admin_password }}'
+payara_user: "glassfish"
+payara_admin_password: "{{ vault_payara_admin_password }}"
 
 # Database root user's username and password
-db_root_username: '{{ vault_db_root_username }}'
-db_root_password: '{{ vault_db_root_password }}'
+db_root_username: "{{ vault_db_root_username }}"
+db_root_password: "{{ vault_db_root_password }}"
 
 # ICAT database hostname, database name, username and password
-db_icat_hostname: 'localhost'
-icat_database: '{{ vault_icat_database }}'
-db_icat_username: '{{ vault_db_icat_username }}'
-db_icat_password: '{{ vault_db_icat_password }}'
+db_icat_hostname: "localhost"
+icat_database: "{{ vault_icat_database }}"
+db_icat_username: "{{ vault_db_icat_username }}"
+db_icat_password: "{{ vault_db_icat_password }}"
 
 # Authn-simple usernames
-authn_root_username: '{{ vault_authn_root_username }}'
-authn_ingest_username: '{{ vault_authn_ingest_username }}'
-authn_reader_username: '{{ vault_authn_reader_username }}'
-authn_icatuser_username: '{{ vault_authn_icatuser_username }}'
+authn_root_username: "{{ vault_authn_root_username }}"
+authn_ingest_username: "{{ vault_authn_ingest_username }}"
+authn_reader_username: "{{ vault_authn_reader_username }}"
+authn_icatuser_username: "{{ vault_authn_icatuser_username }}"
 
 # Authn-simple passwords
-authn_root_password: '{{ vault_authn_root_password }}'
-authn_ingest_password: '{{ vault_authn_ingest_password }}'
-authn_reader_password: '{{ vault_authn_reader_password }}'
-authn_icatuser_password: '{{ vault_authn_icatuser_password }}'
+authn_root_password: "{{ vault_authn_root_password }}"
+authn_ingest_password: "{{ vault_authn_ingest_password }}"
+authn_reader_password: "{{ vault_authn_reader_password }}"
+authn_icatuser_password: "{{ vault_authn_icatuser_password }}"
 
 # Authn-simple server URL
-authn_simple_url: '{{ ansible_fqdn }}'
+authn_simple_url: "{{ ansible_fqdn }}"
 
 # Authn-db server URL
-authn_db_url: '{{ ansible_fqdn }}'
+authn_db_url: "{{ ansible_fqdn }}"
+
+# Authn-anon server URL
+authn_anon_url: "{{ ansible_fqdn }}"
 
 # ICAT Lucene server URL
-lucene_url: '{{ ansible_fqdn }}'
+lucene_url: "{{ ansible_fqdn }}"
 
 # ICAT server URL
-icat_url: '{{ ansible_fqdn }}'
+icat_url: "{{ ansible_fqdn }}"
 
 # IDS server URL
-ids_url: '{{ ansible_fqdn }}'
+ids_url: "{{ ansible_fqdn }}"
 
 # TopCat server URL
-topcat_url: '{{ ansible_fqdn }}'
+topcat_url: "{{ ansible_fqdn }}"
 
 # TopCat database hostname, database name, username and password
-db_topcat_hostname: 'localhost'
-topcat_database: '{{ vault_topcat_database }}'
-db_topcat_username: '{{ vault_db_topcat_username }}'
-db_topcat_password: '{{ vault_db_topcat_password }}'
+db_topcat_hostname: "localhost"
+topcat_database: "{{ vault_topcat_database }}"
+db_topcat_username: "{{ vault_db_topcat_username }}"
+db_topcat_password: "{{ vault_db_topcat_password }}"

--- a/hosts-all.yml
+++ b/hosts-all.yml
@@ -2,7 +2,7 @@
 - hosts: hosts-all
   become: true
   vars_files:
-    - 'group_vars/all/vars.yml'
+    - "group_vars/all/vars.yml"
   roles:
     - role: common
     - role: java
@@ -10,6 +10,7 @@
     - role: icatdb
     - role: payara
     - role: authn-simple
+    - role: authn-anon
     - role: authn-db
     - role: icat-lucene
     - role: icat-server

--- a/roles/authn-anon/defaults/main.yml
+++ b/roles/authn-anon/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+authn_anon_version: "2.0.0"

--- a/roles/authn-anon/files/logback.xml
+++ b/roles/authn-anon/files/logback.xml
@@ -1,0 +1,26 @@
+<configuration>
+
+        <appender name="FILE"
+                class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>${HOME}/logs/authn_anon.log</file>
+                <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                        <fileNamePattern>${HOME}/logs/authn_anon.log.%d{yyyy-MM-dd}.%i.zip
+                        </fileNamePattern>
+                        <maxHistory>30</maxHistory>
+                        <timeBasedFileNamingAndTriggeringPolicy
+                                class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                                <maxFileSize>100MB</maxFileSize>
+                        </timeBasedFileNamingAndTriggeringPolicy>
+                </rollingPolicy>
+
+                <encoder>
+                        <pattern>%date %level [%thread] %C{0} - %msg%n
+                        </pattern>
+                </encoder>
+        </appender>
+
+        <root level="DEBUG">
+                <appender-ref ref="FILE" />
+        </root>
+
+</configuration>

--- a/roles/authn-anon/handlers/authn-anon-handler.yml
+++ b/roles/authn-anon/handlers/authn-anon-handler.yml
@@ -1,0 +1,11 @@
+---
+- name: "Import: Check payara is running"
+  import_tasks: roles/payara/tasks/status.yml
+
+- name: "Re-install authn-anon"
+  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/authn.anon; ./setup -vv install"'
+  become: true
+  become_user: root
+  args:
+    executable: /bin/bash
+  when: payaraStatus.rc == 0

--- a/roles/authn-anon/handlers/main.yml
+++ b/roles/authn-anon/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: "authn-anon-handler"
+  include_tasks: handlers/authn-anon-handler.yml

--- a/roles/authn-anon/meta/main.yml
+++ b/roles/authn-anon/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+  - role: common
+  - role: payara

--- a/roles/authn-anon/tasks/installation.yml
+++ b/roles/authn-anon/tasks/installation.yml
@@ -1,0 +1,21 @@
+---
+- name: "Setup authn-anon"
+  include_tasks: handlers/authn-anon-handler.yml
+
+- name: "Set fact on host to record that authn-anon has been instantiated"
+  ini_file:
+    path: /etc/ansible/facts.d/local.fact
+    section: "instantiations"
+    option: "authn_anon"
+    value: "true"
+    no_extra_spaces: true
+    create: false
+
+- name: "Set fact on host to record version of authn-anon that has been instantiated"
+  ini_file:
+    path: /etc/ansible/facts.d/local.fact
+    section: "versions"
+    option: "authn_anon"
+    value: "{{ authn_anon_version }}"
+    no_extra_spaces: true
+    create: false

--- a/roles/authn-anon/tasks/main.yml
+++ b/roles/authn-anon/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: "Check authn-anon package"
+  stat:
+    path: /home/{{ payara_user }}/downloads/authn.anon-{{ authn_anon_version }}-distro.zip
+  register: packageResult
+
+- name: "Download authn-anon"
+  get_url:
+    url: https://repo.icatproject.org/repo/org/icatproject/authn.anon/{{ authn_anon_version }}/authn.anon-{{ authn_anon_version }}-distro.zip
+    dest: /home/{{ payara_user }}/downloads
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0664
+  when: packageResult.stat.exists is defined and packageResult.stat.exists == false
+
+- name: "Check authn-anon installation"
+  stat:
+    path: /home/{{ payara_user }}/install/authn.anon
+  register: installationResult
+
+- name: "Unarchive authn-anon if not installed"
+  unarchive:
+    src: /home/{{ payara_user }}/downloads/authn.anon-{{ authn_anon_version }}-distro.zip
+    dest: /home/{{ payara_user }}/install
+    remote_src: true
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+  when: installationResult.stat.exists is defined and installationResult.stat.exists == false
+
+- name: "Configure authn-anon setup.properties"
+  template:
+    src: roles/payara/templates/setup.properties.j2
+    dest: /home/{{ payara_user }}/install/authn.anon/setup.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0600
+  notify:
+    - "authn-anon-handler"
+
+- name: "Configure authn-anon run.properties"
+  template:
+    src: templates/run.properties.j2
+    dest: /home/{{ payara_user }}/install/authn.anon/run.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0664
+  notify:
+    - "authn-anon-handler"
+
+- name: "Configure authn-anon logback.xml"
+  copy:
+    src: files/logback.xml
+    dest: /home/{{ payara_user }}/install/authn.anon/logback.xml
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0664
+  notify:
+    - "authn-anon-handler"
+
+- name: "Setup authn-anon if not setup"
+  import_tasks: tasks/installation.yml
+  when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.authn_anon is not defined) or (ansible_local.local.instantiations.authn_anon != 'true')
+
+- name: "Set temporary fact to indicate authn_anon is installed within play"
+  set_fact:
+    authn_anon: true

--- a/roles/authn-anon/tasks/main.yml
+++ b/roles/authn-anon/tasks/main.yml
@@ -37,13 +37,29 @@
   notify:
     - "authn-anon-handler"
 
-- name: "Configure authn-anon run.properties"
+- name: "Check run.properties file existence"
+  local_action: stat path={{ role_path }}/files/run.properties
+  register: runPropertiesResult
+
+- name: "Configure authn-anon run.properties via copying"
+  copy:
+    src: file/run.properties
+    dest: /home/{{ payara_user }}/install/authn.anon/run.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0664
+  when: runPropertiesResult.stat.exists is defined and runPropertiesResult.stat.exists == true
+  notify:
+    - "authn-anon-handler"
+
+- name: "Configure authn-anon run.properties via templating"
   template:
     src: templates/run.properties.j2
     dest: /home/{{ payara_user }}/install/authn.anon/run.properties
     owner: "{{ payara_user }}"
     group: "{{ payara_user }}"
     mode: 0664
+  when: runPropertiesResult.stat.exists is defined and runPropertiesResult.stat.exists == false
   notify:
     - "authn-anon-handler"
 

--- a/roles/authn-anon/tasks/main.yml
+++ b/roles/authn-anon/tasks/main.yml
@@ -39,6 +39,7 @@
 
 - name: "Check run.properties file existence"
   local_action: stat path={{ role_path }}/files/run.properties
+  become: false
   register: runPropertiesResult
 
 - name: "Configure authn-anon run.properties via copying"

--- a/roles/authn-anon/templates/run.properties.j2
+++ b/roles/authn-anon/templates/run.properties.j2
@@ -1,0 +1,11 @@
+# Real comments in this file are marked with '#' whereas commented out lines
+# are marked with '!'
+
+# If access to the anon authentication should only be allowed from certain 
+# IP addresses then provide a space separated list of allowed values. These 
+# take the form of an IPV4 or IPV6 address followed by the number of bits 
+# (starting from the most significant) to consider.
+!ip = 130.246.0.0/16   172.16.68.0/24
+
+# The mechanism label to appear before the user name. This may be omitted.
+mechanism = anon


### PR DESCRIPTION
Adds a role that sets up the `authn.anon` authenticator. Note that most of the logic for automatically put it into the generated files was already in the code, so relatively little code had to be changed.

I have tested that this does in fact install properly such that the authenticator can be used by topcat if one adds the `authn-anon` role to a playbook.

Closes #21 