### PR TITLE
#19 - install packages with latest & update package caches

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,14 +1,23 @@
 ---
+- name: "Update apt cache if running on Debian system"
+  apt:
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
 
-- name: 'Installing common packages'
-  package: name={{ item }} state=present
+- name: "Update yum cache if running on RedHat system"
+  yum:
+    update_cache: yes
+  when: ansible_os_family == 'RedHat'
+
+- name: "Installing common packages"
+  package: name={{ item }} state=latest
   with_items:
-  - htop
-  - unzip
-  - vim
-  - wget
+    - htop
+    - unzip
+    - vim
+    - wget
 
-- name: 'Create ansible config directory on remote hosts'
+- name: "Create ansible config directory on remote hosts"
   file:
     path: /etc/ansible/facts.d
     state: directory
@@ -16,22 +25,22 @@
     group: root
     mode: 0755
 
-- name: 'Check local fact file'
+- name: "Check local fact file"
   stat:
     path: /etc/ansible/facts.d/local.fact
   register: factFileResult
 
-- name: 'Create local fact file on remote hosts to record instantiated software'
+- name: "Create local fact file on remote hosts to record instantiated software"
   blockinfile:
-    path: '/etc/ansible/facts.d/local.fact'
+    path: "/etc/ansible/facts.d/local.fact"
     block: |
       [instantiations]
-      
+
       [versions]
     insertbefore: BOF
-    marker: ''
-    marker_begin: ''
-    marker_end: ''
+    marker: ""
+    marker_begin: ""
+    marker_end: ""
     create: true
     owner: root
     group: root

--- a/roles/dev-common/tasks/main.yml
+++ b/roles/dev-common/tasks/main.yml
@@ -1,54 +1,53 @@
 ---
-
-- name: 'Installing common dev packages'
-  package: name={{ item }} state=present
+- name: "Installing common dev packages"
+  package: name={{ item }} state=latest
   with_items:
-  - git
-  - maven
-  - python-pip
+    - git
+    - maven
+    - python-pip
 
-- name: 'Installing common dev python packages'
+- name: "Installing common dev python packages"
   pip:
-    name: 
+    name:
       - requests-toolbelt
       - wheel
 
-- name: 'Create .m2 directory'
+- name: "Create .m2 directory"
   file:
     path: /home/{{ payara_user }}/.m2
     state: directory
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0775
 
-- name: 'Add maven settings file to maven home'
+- name: "Add maven settings file to maven home"
   template:
     src: templates/settings.xml.j2
     dest: /home/{{ payara_user }}/.m2/settings.xml
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0664
 
-- name: 'Make test ids main folder'
+- name: "Make test ids main folder"
   file:
     path: /home/{{ payara_user }}/test/data/ids/main
     state: directory
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0775
 
-- name: 'Make test ids archive folder'
+- name: "Make test ids archive folder"
   file:
     path: /home/{{ payara_user }}/test/data/ids/archive
     state: directory
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0775
 
-- name: 'Make test ids cache folder'
+- name: "Make test ids cache folder"
   file:
     path: /home/{{ payara_user }}/test/data/ids/cache
     state: directory
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0775

--- a/roles/icat-server/tasks/main.yml
+++ b/roles/icat-server/tasks/main.yml
@@ -1,114 +1,114 @@
 ---
-- name: 'Install common icat-server dependencies'
-  package: name={{ item }} state=present
+- name: "Install common icat-server dependencies"
+  package: name={{ item }} state=latest
   with_items:
     - python-suds
     - python-requests
 
-- name: 'Check icat-server package'
+- name: "Check icat-server package"
   stat:
     path: /home/{{ payara_user }}/downloads/icat.server-{{ icat_server_version }}-distro.zip
   register: packageResult
 
-- name: 'Download icat-server'
+- name: "Download icat-server"
   get_url:
     url: https://repo.icatproject.org/repo/org/icatproject/icat.server/{{ icat_server_version }}/icat.server-{{ icat_server_version }}-distro.zip
     dest: /home/{{ payara_user }}/downloads
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0664
   when: packageResult.stat.exists is defined and packageResult.stat.exists == false
 
-- name: 'Check icat-server installation'
+- name: "Check icat-server installation"
   stat:
     path: /home/{{ payara_user }}/install/icat.server
   register: installationResult
 
-- name: 'Unarchive icat-server if not installed'
+- name: "Unarchive icat-server if not installed"
   unarchive:
     src: /home/{{ payara_user }}/downloads/icat.server-{{ icat_server_version }}-distro.zip
     dest: /home/{{ payara_user }}/install
     remote_src: true
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
   when: installationResult.stat.exists is defined and installationResult.stat.exists == false
 
-- name: 'Create bin directory for the payara user'
+- name: "Create bin directory for the payara user"
   file:
     path: /home/{{ payara_user }}/bin
     state: directory
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0775
 
-- name: 'Add path to payara user bin directory for icat-server to PATH variable'
+- name: "Add path to payara user bin directory for icat-server to PATH variable"
   lineinfile:
     path: /home/{{ payara_user }}/.bashrc
-    line: 'export PATH=$PATH:/home/{{ payara_user }}/bin'
+    line: "export PATH=$PATH:/home/{{ payara_user }}/bin"
 
-- name: 'Create a stash directory for assembling configurations'
+- name: "Create a stash directory for assembling configurations"
   file:
     path: /home/{{ payara_user }}/stash
     state: directory
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0775
 
-- name: 'Create a stash directory for icat-server configs'
+- name: "Create a stash directory for icat-server configs"
   file:
     path: /home/{{ payara_user }}/stash/icat-server
     state: directory
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0775
 
-- name: 'Copy over payara setup.properties'
+- name: "Copy over payara setup.properties"
   template:
     src: roles/payara/templates/setup.properties.j2
     dest: /home/{{ payara_user }}/stash/icat-server/1-part
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0664
 
-- name: 'Copy over icat-server setup.properties'
+- name: "Copy over icat-server setup.properties"
   template:
     src: templates/setup.properties.j2
     dest: /home/{{ payara_user }}/stash/icat-server/2-part
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0664
 
-- name: 'Configure icat-server setup.properties by concatenation of files in the stash'
+- name: "Configure icat-server setup.properties by concatenation of files in the stash"
   assemble:
     src: /home/{{ payara_user }}/stash/icat-server
     dest: /home/{{ payara_user }}/install/icat.server/setup.properties
     delimiter: '\n'
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0600
   notify:
     - "icat-server-handler"
 
-- name: 'Configure icat-server run.properties'
+- name: "Configure icat-server run.properties"
   template:
     src: templates/run.properties.j2
     dest: /home/{{ payara_user }}/install/icat.server/run.properties
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0664
   notify:
     - "icat-server-handler"
 
-- name: 'Configure icat-server logback.xml'
+- name: "Configure icat-server logback.xml"
   copy:
     src: files/logback.xml
     dest: /home/{{ payara_user }}/install/icat.server/logback.xml
-    owner: '{{ payara_user }}'
-    group: '{{ payara_user }}'
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
     mode: 0664
   notify:
     - "icat-server-handler"
 
-- name: 'Setup icat-server if not setup'
+- name: "Setup icat-server if not setup"
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.icat_server is not defined) or (ansible_local.local.instantiations.icat_server != 'true')

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -1,14 +1,13 @@
 ---
-
-- name: 'Install java packages for Red Hat systems (EL 7)'
-  package: name={{ item }} state=present
+- name: "Install java packages for Red Hat systems (EL 7)"
+  package: name={{ item }} state=latest
   with_items:
-  - java-1.8.0-openjdk-headless
-  - java-1.8.0-openjdk-devel
+    - java-1.8.0-openjdk-headless
+    - java-1.8.0-openjdk-devel
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'
 
-- name: 'Install java packages for Debian systems (Ubuntu 16.04)'
-  package: name={{ item }} state=present
+- name: "Install java packages for Debian systems (Ubuntu 16.04)"
+  package: name={{ item }} state=latest
   with_items:
-  - openjdk-8-jdk-headless
+    - openjdk-8-jdk-headless
   when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '16'

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,50 +1,49 @@
 ---
-
 - include_vars: vars/redhat.yml
   when: ansible_os_family == 'RedHat'
 
 - include_vars: vars/debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: 'Install mariadb packages'
-  package: name={{ item }} state=present
-  with_items: '{{ mariadb_pkgs }}'
+- name: "Install mariadb packages"
+  package: name={{ item }} state=latest
+  with_items: "{{ mariadb_pkgs }}"
 
-- name: 'Configure default storage engine'
+- name: "Configure default storage engine"
   copy:
     src: files/storage-engine.cnf
-    dest: '{{ mariadb_config_dir }}/storage-engine.cnf'
+    dest: "{{ mariadb_config_dir }}/storage-engine.cnf"
     owner: root
     group: root
     mode: 0644
   notify:
-  - "mariadb-handler"
+    - "mariadb-handler"
 
-- name: 'Configure default character set'
+- name: "Configure default character set"
   copy:
     src: files/character-set.cnf
-    dest: '{{ mariadb_config_dir }}/character-set.cnf'
+    dest: "{{ mariadb_config_dir }}/character-set.cnf"
     owner: root
     group: root
     mode: 0644
   notify:
-  - "mariadb-handler"
+    - "mariadb-handler"
 
-- name: 'Remove any mariadb specific conf as these defaults override our own'
+- name: "Remove any mariadb specific conf as these defaults override our own"
   lineinfile:
-    path: '{{ mariadb_config_dir }}/../my.cnf'
+    path: "{{ mariadb_config_dir }}/../my.cnf"
     regexp: '\/mariadb\.conf\.d\/'
     state: absent
   notify:
-  - "mariadb-handler"
+    - "mariadb-handler"
 
-- name: 'Enable and start dbms daemon'
+- name: "Enable and start dbms daemon"
   service:
-    name: '{{ mariadb_daemon }}'
+    name: "{{ mariadb_daemon }}"
     state: started
     enabled: true
 
-- name: 'Setup mariadb if not setup'
+- name: "Setup mariadb if not setup"
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.{{ mariadb_daemon }} is not defined) or (ansible_local.local.instantiations.{{ mariadb_daemon }} != 'true')
 


### PR DESCRIPTION
Packages are now installed using the "latest" keyword rather than just "stable" - this means subsequent runs will upgrade the package in question. Additionally, I have added commands to update the package caches at the start of the common role.

Closes #19 