### PR TITLE
Make icat-lucene optional

### DIFF
--- a/roles/icat-lucene/tasks/main.yml
+++ b/roles/icat-lucene/tasks/main.yml
@@ -69,3 +69,7 @@
 - name: 'Setup icat-lucene if not setup'
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.icat_lucene is not defined) or (ansible_local.local.instantiations.icat_lucene != 'true')
+
+- name: "Set temporary fact to indicate icat-lucene is installed within play"
+  set_fact:
+    icat_lucene: true

--- a/roles/icat-server/meta/main.yml
+++ b/roles/icat-server/meta/main.yml
@@ -4,4 +4,3 @@ dependencies:
   - role: icatdb
   - role: payara
   - role: authn-simple
-  - role: icat-lucene

--- a/roles/icat-server/templates/run.properties.j2
+++ b/roles/icat-server/templates/run.properties.j2
@@ -64,12 +64,21 @@ notification.Datafile = CU
 log.list = SESSION WRITE READ INFO
 
 # Lucene
+{% if icat_lucene is defined and icat_lucene %}
 lucene.url = https://{{ lucene_url }}:8181
 lucene.populateBlockSize = 1000
 lucene.directory = /home/{{ payara_user }}/data/lucene
 lucene.backlogHandlerIntervalSeconds = 60
 lucene.enqueuedRequestIntervalSeconds = 5
 lucene.entitiesToIndex = Dataset Investigation InvestigationUser DatasetParameter InvestigationParameter Sample
+{% else %}
+!lucene.url = https://localhost:8181
+!lucene.populateBlockSize = 10000
+!lucene.directory = /home/{{ payara_user }}/data/lucene
+!lucene.backlogHandlerIntervalSeconds = 60
+!lucene.enqueuedRequestIntervalSeconds = 5
+!lucene.entitiesToIndex = Dataset Investigation InvestigationUser DatasetParameter InvestigationParameter Sample
+{% endif %}
 
 # List members of cluster
 !cluster = http://vm200.nubes.stfc.ac.uk:8080 https://smfisher:8181


### PR DESCRIPTION
This removes the icat-lucene role from the dependencies of the icat-server role and makes the lucene configuration in icat-server's run.properties dependent on the icat-lucene role having been installed.