### PR TITLE
Compatability with icat-server versions <= 4.8

### DIFF
--- a/roles/icat-server/tasks/compat48.yml
+++ b/roles/icat-server/tasks/compat48.yml
@@ -1,0 +1,25 @@
+---
+
+- name: "Copy setup.properties to icat-setup.properties"
+  copy:
+    remote_src: yes
+    src: /home/{{ payara_user }}/install/icat.server/setup.properties
+    dest: /home/{{ payara_user }}/install/icat.server/icat-setup.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0600
+
+- name: "Copy run.properties to icat.properties"
+  copy:
+    remote_src: yes
+    src: /home/{{ payara_user }}/install/icat.server/run.properties
+    dest: /home/{{ payara_user }}/install/icat.server/icat.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0644
+
+- name: "Fix setup_utils.py for compatability with Payara"
+  replace:
+    path: /home/{{ payara_user }}/install/icat.server/setup_utils.py
+    regexp: 'pos = vline\.find\("\("\)'
+    replace: 'pos = vline.find("#")'

--- a/roles/icat-server/tasks/main.yml
+++ b/roles/icat-server/tasks/main.yml
@@ -109,6 +109,10 @@
   notify:
     - "icat-server-handler"
 
+- name: "Run tasks for icat-server versions <= 4.8"
+  import_tasks: tasks/compat48.yml
+  when: icat_server_compat48 is defined and icat_server_compat48
+
 - name: "Setup icat-server if not setup"
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.icat_server is not defined) or (ansible_local.local.instantiations.icat_server != 'true')

--- a/roles/icat-server/templates/run.properties.j2
+++ b/roles/icat-server/templates/run.properties.j2
@@ -60,7 +60,13 @@ notification.Dataset = CU
 notification.Datafile = CU
 
 # Call logging setup
+{% if icat_server_compat46 is defined and icat_server_compat46 %}
+log.list = file table
+log.file = S
+log.table = S
+{% else %}
 log.list = SESSION WRITE READ INFO
+{% endif %}
 
 # Lucene
 lucene.url = https://{{ lucene_url }}:8181

--- a/roles/icat-server/templates/setup.properties.j2
+++ b/roles/icat-server/templates/setup.properties.j2
@@ -1,4 +1,7 @@
 # Oracle
+{% if icat_server_compat46 is defined and icat_server_compat46 %}
+!db.vendor = oracle
+{% endif %}
 !db.driver = oracle.jdbc.pool.OracleDataSource
 !db.url = jdbc:oracle:thin:@//{{ db_icat_hostname }}:1521/{{ icat_database }}
 !db.username = {{ db_icat_username }}
@@ -9,6 +12,9 @@
 !db.logging = FINE
 
 # MySQL
+{% if icat_server_compat46 is defined and icat_server_compat46 %}
+db.vendor = mysql
+{% endif %}
 db.driver = com.mysql.jdbc.jdbc2.optional.MysqlDataSource
 db.url = jdbc:mysql://{{ db_icat_hostname }}:3306/{{ icat_database }}
 db.username = {{ db_icat_username }}

--- a/roles/icat-server/vars/main.yml
+++ b/roles/icat-server/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+icat_server_compat46: '{{ not not ( icat_server_version | regex_search("^4\.[0-6]\.") ) }}'
+icat_server_compat48: '{{ not not ( icat_server_version | regex_search("^4\.[0-8]\.") ) }}'


### PR DESCRIPTION
Fixes the names of the .properties files, the glassfish version check when running setup, and some .properties file changes that cause install to fail.