### PR TITLE
Compatability with authn-simple and authn-ldap versions 1.x

### DIFF
--- a/roles/authn-ldap/tasks/compat1x.yml
+++ b/roles/authn-ldap/tasks/compat1x.yml
@@ -1,0 +1,25 @@
+---
+
+- name: "Copy setup.properties to authn_ldap-setup.properties"
+  copy:
+    remote_src: yes
+    src: /home/{{ payara_user }}/install/authn.ldap/setup.properties
+    dest: /home/{{ payara_user }}/install/authn.ldap/authn_ldap-setup.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0600
+
+- name: "Copy run.properties to authn_ldap.properties"
+  copy:
+    remote_src: yes
+    src: /home/{{ payara_user }}/install/authn.ldap/run.properties
+    dest: /home/{{ payara_user }}/install/authn.ldap/authn_ldap.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0644
+
+- name: "Fix setup_utils.py for compatability with Payara"
+  replace:
+    path: /home/{{ payara_user }}/install/authn.ldap/setup_utils.py
+    regexp: 'pos = vline\.find\("\("\)'
+    replace: 'pos = vline.find("#")'

--- a/roles/authn-ldap/tasks/main.yml
+++ b/roles/authn-ldap/tasks/main.yml
@@ -91,6 +91,10 @@
   notify:
     - "authn-ldap-handler"
 
+- name: "Run tasks for authn-ldap versions 1.x"
+  import_tasks: tasks/compat1x.yml
+  when: authn_ldap_compat1x is defined and authn_ldap_compat1x
+
 - name: "Setup authn-ldap if not setup"
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.authn_ldap is not defined) or (ansible_local.local.instantiations.authn_ldap != 'true')

--- a/roles/authn-ldap/vars/main.yml
+++ b/roles/authn-ldap/vars/main.yml
@@ -1,0 +1,3 @@
+---
+
+authn_ldap_compat1x: '{{ not not ( authn_ldap_version | regex_search("^1\.") ) }}'

--- a/roles/authn-simple/tasks/compat1x.yml
+++ b/roles/authn-simple/tasks/compat1x.yml
@@ -1,0 +1,25 @@
+---
+
+- name: "Copy setup.properties to authn_simple-setup.properties"
+  copy:
+    remote_src: yes
+    src: /home/{{ payara_user }}/install/authn.simple/setup.properties
+    dest: /home/{{ payara_user }}/install/authn.simple/authn_simple-setup.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0600
+
+- name: "Copy run.properties to authn_simple.properties"
+  copy:
+    remote_src: yes
+    src: /home/{{ payara_user }}/install/authn.simple/run.properties
+    dest: /home/{{ payara_user }}/install/authn.simple/authn_simple.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0644
+
+- name: "Fix setup_utils.py for compatability with Payara"
+  replace:
+    path: /home/{{ payara_user }}/install/authn.simple/setup_utils.py
+    regexp: 'pos = vline\.find\("\("\)'
+    replace: 'pos = vline.find("#")'

--- a/roles/authn-simple/tasks/main.yml
+++ b/roles/authn-simple/tasks/main.yml
@@ -91,6 +91,10 @@
   notify:
     - "authn-simple-handler"
 
+- name: "Run tasks for authn-simple versions 1.x"
+  import_tasks: tasks/compat1x.yml
+  when: authn_simple_compat1x is defined and authn_simple_compat1x
+
 - name: "Setup authn-simple if not setup"
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.authn_simple is not defined) or (ansible_local.local.instantiations.authn_simple != 'true')

--- a/roles/authn-simple/vars/main.yml
+++ b/roles/authn-simple/vars/main.yml
@@ -1,0 +1,3 @@
+---
+
+authn_simple_compat1x: '{{ not not ( authn_simple_version | regex_search("^1\.") ) }}'

--- a/roles/icat-server/templates/run.properties.j2
+++ b/roles/icat-server/templates/run.properties.j2
@@ -29,7 +29,11 @@ authn.db.url = https://{{ authn_db_url }}:8181
 {% endif %}
 
 {% if ansible_local.local.instantiations.authn_ldap is defined and ansible_local.local.instantiations.authn_ldap == 'true' %}
+{% if authn_ldap_compat1x is defined and authn_ldap_compat1x %}
+authn.ldap.jndi = java:global/authn.ldap-{{ authn_ldap_version }}/LDAP_Authenticator
+{% else %}
 authn.ldap.url = https://{{ authn_ldap_url }}:8181
+{% endif %}
 authn.ldap.admin = true
 authn.ldap.friendly = Federal Id
 {% else %}
@@ -39,7 +43,11 @@ authn.ldap.friendly = Federal Id
 {% endif %}
 
 {% if ansible_local.local.instantiations.authn_simple is defined and ansible_local.local.instantiations.authn_simple == 'true' %}
+{% if authn_simple_compat1x is defined and authn_simple_compat1x %}
+authn.simple.jndi = java:global/authn.simple-{{ authn_simple_version }}/SIMPLE_Authenticator
+{% else %}
 authn.simple.url = https://{{ authn_simple_url }}:8181 
+{% endif %}
 authn.simple.friendly = Simple
 {% else %}
 !authn.simple.url = https://localhost:8181 


### PR DESCRIPTION
Fixes the names of the .properties files, the glassfish version check when running setup, and adds the required jndi property to icat-server's run.properties.