### PR TITLE
Changed test for mariadb installation 'or' -> 'and'

### DIFF
--- a/roles/topcat/tasks/main.yml
+++ b/roles/topcat/tasks/main.yml
@@ -41,7 +41,7 @@
     name: "{{ topcat_database }}"
     login_user: "{{ db_root_username }}"
     login_password: "{{ db_root_password }}"
-  when: (ansible_local is defined) and (ansible_local.local is defined) and (ansible_local.local.instantiations is defined) and (ansible_local.local.instantiations.mariadb is defined) or (ansible_local.local.instantiations.mariadb == 'true')
+  when: (ansible_local is defined) and (ansible_local.local is defined) and (ansible_local.local.instantiations is defined) and (ansible_local.local.instantiations.mariadb is defined) and (ansible_local.local.instantiations.mariadb == 'true')
 
 - name: "Create user for topcat database"
   mysql_user:
@@ -50,7 +50,7 @@
     priv: "{{ topcat_database }}.*:ALL,GRANT"
     login_user: "{{ db_root_username }}"
     login_password: "{{ db_root_password }}"
-  when: (ansible_local is defined) and (ansible_local.local is defined) and (ansible_local.local.instantiations is defined) and (ansible_local.local.instantiations.mariadb is defined) or (ansible_local.local.instantiations.mariadb == 'true')
+  when: (ansible_local is defined) and (ansible_local.local is defined) and (ansible_local.local.instantiations is defined) and (ansible_local.local.instantiations.mariadb is defined) and (ansible_local.local.instantiations.mariadb == 'true')
 
 - name: "Check topcat-setup.properties file existence"
   local_action: stat path={{ role_path }}/files/topcat-setup.properties


### PR DESCRIPTION
The logic of this test means that it always expects mariadb to be installed. Changed an 'or' to an 'and' to allow installation on machine using Oracle and not Mariadb.