### PR TITLE
Update Payara setup-glassfish Script URL

### DIFF
--- a/icatdb-minimal-hosts.yml
+++ b/icatdb-minimal-hosts.yml
@@ -1,0 +1,14 @@
+---
+- hosts: icatdb-minimal-hosts
+  become: true
+  vars_files:
+    - "group_vars/all/vars.yml"
+  roles:
+    - role: common
+    - role: java
+    - role: mariadb
+    - role: icatdb
+    - role: payara
+    - role: authn-simple
+    - role: icat-lucene
+    - role: icat-server

--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -91,7 +91,7 @@
 
 - name: 'Download payara setup script'
   get_url:
-    url: https://raw.githubusercontent.com/icatproject/icat.utils/master/src/main/scripts/setup-glassfish.py
+    url: https://raw.githubusercontent.com/icatproject/icatproject.github.io/gatsbyjs/static/misc/scripts/setup-glassfish.py
     dest: /home/{{ payara_user }}/scripts
     owner: '{{ payara_user }}'
     group: '{{ payara_user }}'

--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -91,7 +91,7 @@
 
 - name: 'Download payara setup script'
   get_url:
-    url: https://icatproject.org/misc/scripts/setup-glassfish.py
+    url: https://raw.githubusercontent.com/icatproject/icat.utils/master/src/main/scripts/setup-glassfish.py
     dest: /home/{{ payara_user }}/scripts
     owner: '{{ payara_user }}'
     group: '{{ payara_user }}'


### PR DESCRIPTION
As per #50, since icatproject.org is currently down, the playbook fails when it attempts to download the `setup-glassfish.py` script. I've updated this link to the GitHub repo for icatproject.github.io which works.

I've also added another hosts file which is used to build a local ICAT instance for [DataGateway API's](https://github.com/ral-facilities/datagateway-api) GitHub Actions workflow, with a reduced number of roles compared to `hosts-all.yml`. This significantly reduces the amount of time it takes to create an ICAT instance for this use case and is very useful for this purpose.