### PR TITLE
Update ICAT Server version to use 4.11.1

### DIFF
--- a/roles/icat-server/defaults/main.yml
+++ b/roles/icat-server/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 
-icat_server_version: '4.10.0'
+icat_server_version: '4.11.1'


### PR DESCRIPTION
This fixes #61.

As explained in the original issue, this is only a change to the version of ICAT Server being used in the Ansible. This has been tested and works.