### PR TITLE
Fix bug with ICAT Server Lucene config conditional

### DIFF
--- a/roles/icat-server/templates/run.properties.j2
+++ b/roles/icat-server/templates/run.properties.j2
@@ -87,7 +87,7 @@ log.list = SESSION WRITE READ INFO
 {% endif %}
 
 # Lucene
-{% if icat_lucene is defined and icat_lucene %}
+{% if ansible_local.local.instantiations.icat_lucene is defined and ansible_local.local.instantiations.icat_lucene == 'true' %}
 lucene.url = https://{{ lucene_url }}:8181
 lucene.populateBlockSize = 1000
 lucene.directory = /home/{{ payara_user }}/data/lucene


### PR DESCRIPTION
This fixes #63 

A small change to fix a bug found while using ICAT Ansible to setup CI for DataGateway. The conditional will now evaluate to true when the `icat_lucene` variable is true (this is done during the installation task for Lucene). 

This has been tested on DataGateway's CI - I've outputted ICAT Server's `run.properties` which shows this change works as expected:
![image](https://user-images.githubusercontent.com/32678030/125785955-31c1de22-cd34-4110-af89-764cfade0a56.png)
