### PR TITLE
Add anon auth role to DataGateway API hosts file

### DIFF
--- a/icatdb-minimal-hosts.yml
+++ b/icatdb-minimal-hosts.yml
@@ -10,5 +10,6 @@
     - role: icatdb
     - role: payara
     - role: authn-simple
+    - role: authn-anon
     - role: icat-lucene
     - role: icat-server


### PR DESCRIPTION
A simple change that adds the anon role to the hosts file used on DataGateway API's CI. This is needed because the API now uses the anon authenticator in its tests. This role is used on DataGateway's CI and there are no issues.