### PR TITLE
Make Dev Common work with Ubuntu 20

### DIFF
--- a/roles/dev-common/tasks/main.yml
+++ b/roles/dev-common/tasks/main.yml
@@ -1,10 +1,16 @@
 ---
+- include_vars: vars/redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include_vars: vars/debian-16.yml
+  when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '16'
+
+- include_vars: vars/debian-20.yml
+  when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '20'
+
 - name: "Installing common dev packages"
   package: name={{ item }} state=latest
-  with_items:
-    - git
-    - maven
-    - python-pip
+  with_items: "{{ dev_common_pkgs }}"
 
 - name: "Installing common dev python packages"
   pip:

--- a/roles/dev-common/vars/debian-16.yml
+++ b/roles/dev-common/vars/debian-16.yml
@@ -1,0 +1,5 @@
+---
+dev_common_pkgs:
+  - git
+  - maven
+  - python-pip

--- a/roles/dev-common/vars/debian-20.yml
+++ b/roles/dev-common/vars/debian-20.yml
@@ -1,0 +1,5 @@
+---
+dev_common_pkgs:
+  - git
+  - maven
+  - python3-pip

--- a/roles/dev-common/vars/redhat.yml
+++ b/roles/dev-common/vars/redhat.yml
@@ -1,0 +1,5 @@
+---
+dev_common_pkgs:
+  - git
+  - maven
+  - python-pip


### PR DESCRIPTION
The ICAT ansible with a Dev Common role fails with the following error when it is run on Ubuntu 20:
```
failed: [localhost] (item=python-pip) => {"ansible_loop_var": "item", "changed": false, "item": "python-pip", "msg": "No package matching 'python-pip' is available"}
```
This is because Python 2 is no longer available with Ubuntu 20 by default. This PR fixes this by installing `python3-pip` when it detects that a Debian 20 os is used.