### PR TITLE
Re-Template ICAT Server's run.properties when other ICAT Components are installed

### DIFF
--- a/roles/authn-anon/handlers/main.yml
+++ b/roles/authn-anon/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: "authn-anon-handler"
   include_tasks: handlers/authn-anon-handler.yml
+
+- name: "icat-server-handler"
+  include_tasks: roles/icat-server/handlers/icat-server-handler.yml

--- a/roles/authn-ip_clf/handlers/main.yml
+++ b/roles/authn-ip_clf/handlers/main.yml
@@ -2,3 +2,6 @@
 
 - name: "authn-ip_clf-handler"
   include_tasks: handlers/authn-ip_clf-handler.yml
+
+- name: "icat-server-handler"
+  include_tasks: roles/icat-server/handlers/icat-server-handler.yml

--- a/roles/authn-ldap/handlers/main.yml
+++ b/roles/authn-ldap/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: "authn-ldap-handler"
   include_tasks: handlers/authn-ldap-handler.yml
+
+- name: "icat-server-handler"
+  include_tasks: roles/icat-server/handlers/icat-server-handler.yml

--- a/roles/authn-simple/handlers/main.yml
+++ b/roles/authn-simple/handlers/main.yml
@@ -2,3 +2,6 @@
 
 - name: "authn-simple-handler"
   include_tasks: handlers/authn-simple-handler.yml
+
+- name: "icat-server-handler"
+  include_tasks: roles/icat-server/handlers/icat-server-handler.yml

--- a/roles/authn-uows_clf/handlers/main.yml
+++ b/roles/authn-uows_clf/handlers/main.yml
@@ -2,3 +2,6 @@
 
 - name: "authn-uows_clf-handler"
   include_tasks: handlers/authn-uows_clf-handler.yml
+
+- name: "icat-server-handler"
+  include_tasks: roles/icat-server/handlers/icat-server-handler.yml

--- a/roles/icat-lucene/handlers/main.yml
+++ b/roles/icat-lucene/handlers/main.yml
@@ -2,3 +2,6 @@
 
 - name: "icat-lucene-handler"
   include_tasks: handlers/icat-lucene-handler.yml
+
+- name: "icat-server-handler"
+  include_tasks: roles/icat-server/handlers/icat-server-handler.yml

--- a/roles/icat-server/handlers/icat-server-handler.yml
+++ b/roles/icat-server/handlers/icat-server-handler.yml
@@ -3,6 +3,9 @@
 - name: 'Import: Check payara is running'
   import_tasks: roles/payara/tasks/status.yml
 
+- name: 'Import: Configure run.properties'
+  import_tasks: roles/icat-server/tasks/create-run-properties.yml
+
 - name: 'Re-install icat-server'
   shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/icat.server; python2 setup -vv install"'
   become: true

--- a/roles/icat-server/tasks/create-run-properties.yml
+++ b/roles/icat-server/tasks/create-run-properties.yml
@@ -1,0 +1,26 @@
+---
+
+- name: "Check run.properties file existence"
+  local_action: stat path={{ role_path }}/files/run.properties
+  become: false
+  register: runPropertiesResult
+
+- name: "Configure icat-server run.properties via copying"
+  copy:
+    src: files/run.properties
+    dest: /home/{{ payara_user }}/install/icat.server/run.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0664
+  when: runPropertiesResult.stat.exists is defined and runPropertiesResult.stat.exists == true
+
+- name: "Configure icat-server run.properties via templating"
+  template:
+    # Role path doesn't always point to icat-server when called from handler which is called from another role
+    # Going back a directory then selecting icat-server fixes this
+    src: '{{ role_path }}/../icat-server/templates/run.properties.j2'
+    dest: /home/{{ payara_user }}/install/icat.server/run.properties
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user }}"
+    mode: 0664
+  when: runPropertiesResult.stat.exists is defined and runPropertiesResult.stat.exists == false

--- a/roles/icat-server/tasks/main.yml
+++ b/roles/icat-server/tasks/main.yml
@@ -79,30 +79,8 @@
   notify:
     - "icat-server-handler"
 
-- name: "Check run.properties file existence"
-  local_action: stat path={{ role_path }}/files/run.properties
-  become: false
-  register: runPropertiesResult
-
-- name: "Configure icat-server run.properties via copying"
-  copy:
-    src: files/run.properties
-    dest: /home/{{ payara_user }}/install/icat.server/run.properties
-    owner: "{{ payara_user }}"
-    group: "{{ payara_user }}"
-    mode: 0664
-  when: runPropertiesResult.stat.exists is defined and runPropertiesResult.stat.exists == true
-  notify:
-    - "icat-server-handler"
-
-- name: "Configure icat-server run.properties via templating"
-  template:
-    src: templates/run.properties.j2
-    dest: /home/{{ payara_user }}/install/icat.server/run.properties
-    owner: "{{ payara_user }}"
-    group: "{{ payara_user }}"
-    mode: 0664
-  when: runPropertiesResult.stat.exists is defined and runPropertiesResult.stat.exists == false
+- name: "Configure icat-server run.properties"
+  import_tasks: tasks/create-run-properties.yml
   notify:
     - "icat-server-handler"
 


### PR DESCRIPTION
This PR closes #14.

The linked issue reports that if the DB authenticator is installed after the ICAT Server role, the ICAT Server `run.properties` file will not be updated to reflect the additional config needed to run the DB authenticator in ICAT Server; the linked issue shows the additional config that should be present in the file. Essentially, when the authenticator is installed, `run.properties` was not configured again so there wasn't a chance for the new config to be added. Since [run.properties.j2](https://github.com/icatproject-contrib/icat-ansible/blob/master/roles/icat-server/templates/run.properties.j2) references Ansible variables to most of the authenticator roles and the Lucene role, this impacts more than just the `authn_db` role.

To fix this bug, I've moved the creation/templating of the ICAT Server `run.properties` into its own file (`create-run-properties.yml`).  This means I'm able to import this file in `icat-server-handler.yml` so `run.properties` can be reconfigured each time that handler is called. That handler is called in the affected roles; it was [already present in authn-db](https://github.com/icatproject-contrib/icat-ansible/blob/master/roles/authn-db/handlers/main.yml#L6), but I've added it to the other roles in 5aebac6528351d590b7ab63eb175cb3d93cbaf54.

I have tested this in https://github.com/icatproject-contrib/icat-ansible/tree/test-authn-db where authn-db is installed after icat-server, unlike the original version of `hosts-all.yml`. The CI has a tmate session that activates at the end of the run so you can trigger the CI on that branch and check out the `run.properties` file to confirm the changes work as expected.