### PR TITLE
Don't use loops with the package module

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -10,12 +10,13 @@
   when: ansible_os_family == 'RedHat'
 
 - name: "Installing common packages"
-  package: name={{ item }} state=latest
-  with_items:
-    - htop
-    - unzip
-    - vim
-    - wget
+  package:
+    state: latest
+    name:
+      - htop
+      - unzip
+      - vim
+      - wget
 
 - name: "Create ansible config directory on remote hosts"
   file:

--- a/roles/dev_common/tasks/main.yml
+++ b/roles/dev_common/tasks/main.yml
@@ -9,8 +9,9 @@
   when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '20'
 
 - name: "Installing common dev packages"
-  package: name={{ item }} state=latest
-  with_items: "{{ dev_common_pkgs }}"
+  package:
+    state: latest
+    name: "{{ dev_common_pkgs }}"
 
 - name: "Installing common dev python packages"
   pip:

--- a/roles/icat_server/tasks/main.yml
+++ b/roles/icat_server/tasks/main.yml
@@ -9,8 +9,9 @@
   when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '20'
 
 - name: "Install common icat_server dependencies"
-  package: name={{ item }} state=latest
-  with_items: "{{ icat_server_pkgs }}"
+  package:
+    state: latest
+    name: "{{ icat_server_pkgs }}"
 
 - name: "Check icat_server package"
   stat:

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -1,13 +1,15 @@
 ---
 - name: "Install java packages for Red Hat systems (EL 7)"
-  package: name={{ item }} state=latest
-  with_items:
-    - java-1.8.0-openjdk-headless
-    - java-1.8.0-openjdk-devel
+  package:
+    state: latest
+    name:
+      - java-1.8.0-openjdk-headless
+      - java-1.8.0-openjdk-devel
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'
 
 - name: "Install java packages for Debian systems (Ubuntu 16.04 & 20.04)"
-  package: name={{ item }} state=latest
-  with_items:
-    - openjdk-8-jdk-headless
+  package:
+    state: latest
+    name:
+      - openjdk-8-jdk-headless
   when: ansible_os_family == 'Debian' and ( ansible_distribution_major_version == '16' or ansible_distribution_major_version == '20')

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -9,8 +9,9 @@
   when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '20'
 
 - name: "Install mariadb packages"
-  package: name={{ item }} state=latest
-  with_items: "{{ mariadb_pkgs }}"
+  package:
+    state: latest
+    name: "{{ mariadb_pkgs }}"
 
 - name: "Configure default storage engine"
   copy:


### PR DESCRIPTION
This passes a list of packages to the package module instead of looping and passing 1 package at a time. This speeds thing up, especially when the packages are already installed.