### PR TITLE
Fix the mariadb installation

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,6 +31,12 @@ jobs:
     - name: Change hostname to localhost
       run: sudo hostname -b localhost
 
+    - name: Remove existing mysql
+      run: |
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        sudo apt-get remove --purge "mysql*"
+        sudo rm -rf /var/lib/mysql* /etc/mysql
+
     - name: Run ICAT Ansible Playbook
       run: |
         ansible-playbook hosts_all.yml -i hosts --vault-password-file vault_pass.txt -vv

--- a/roles/mariadb/files/usr.sbin.mysqld
+++ b/roles/mariadb/files/usr.sbin.mysqld
@@ -1,8 +1,0 @@
-/usr/sbin/mysqld flags=(attach_disconnected,complain) {
-  # Allow Systemd notify access
-  /{,var/}run/systemd/notify w,
-
-  /proc/*/status r,
-  /sys/devices/system/node/ r,
-  /sys/devices/system/node/node0/meminfo r,
-}

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -40,36 +40,6 @@
   notify:
     - "mariadb-handler"
 
-- name: "Inject Apparmor config"
-  copy:
-    src: files/usr.sbin.mysqld
-    dest: /etc/apparmor.d/usr.sbin.mysqld
-    owner: root
-    group: root
-    mode: 0644
-  when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '20'
-
-- name: "Restart apparmor"
-  service:
-    name: apparmor
-    state: restarted
-    enabled: true
-  when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '20'
-
-- name: "Remove mysql files"
-  file:
-    path: /var/lib/mysql/
-    state: absent
-  when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '20'
-
-- name: "mysql install db"
-  shell: "mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql"
-  become: true
-  become_user: root
-  args:
-    executable: /bin/bash
-  when: ansible_os_family == 'Debian' and ansible_distribution_major_version == '20'
-
 - name: "Enable and start dbms daemon"
   service:
     name: "{{ mariadb_daemon }}"
@@ -78,7 +48,7 @@
 
 - name: "Setup mariadb if not setup"
   import_tasks: tasks/installation.yml
-  when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations[mariadb_daemon] is not defined) or (ansible_local.local.instantiations[mariadb_daemon] != 'true')
+  when: not (ansible_local.local.instantiations.mariadb | default(false) | bool)
 
 - name: "Flush handlers so that mariadb daemon has been restarted before any databases are created if config has changed"
   meta: flush_handlers


### PR DESCRIPTION
 - Removes the custom steps for Ubuntu 20.04 which are no longer necessary since the mariadb-server package now has a blank Apparmor profile.
 - Corrects the conditional for the installation task. The fact set in `installation.yml` is always called `mariadb` and not named after the daemon.