### PR TITLE
Download the JDBC drivers for mysql/oracle

### DIFF
--- a/roles/mariadb/tasks/installation.yml
+++ b/roles/mariadb/tasks/installation.yml
@@ -22,3 +22,7 @@
     value: 'true'
     no_extra_spaces: true
     create: false
+
+- name: 'Force ansible to regather local facts so that we know mariadb has been installed'
+  setup:
+    filter: ansible_local

--- a/roles/mariadb/vars/debian-16.yml
+++ b/roles/mariadb/vars/debian-16.yml
@@ -5,4 +5,3 @@ mariadb_pkgs:
   - mariadb-server
   - mariadb-client
   - python-mysqldb
-  - libmysql-java

--- a/roles/mariadb/vars/debian-20.yml
+++ b/roles/mariadb/vars/debian-20.yml
@@ -7,4 +7,3 @@ mariadb_pkgs:
   - mariadb-server
   - mariadb-client
   - python3-mysqldb
-  - libmariadb-java

--- a/roles/mariadb/vars/redhat.yml
+++ b/roles/mariadb/vars/redhat.yml
@@ -5,4 +5,3 @@ mariadb_pkgs:
   - mariadb-server
   - mariadb
   - MySQL-python
-  - mysql-connector-java

--- a/roles/payara/defaults/main.yml
+++ b/roles/payara/defaults/main.yml
@@ -3,5 +3,8 @@
 payara_version: '4.1.2.181'
 payara_directory: 'payara{{ payara_version }}'
 payara_domain: 'domain1'
+install_mysql_connector_java: '{{ ansible_local.local.instantiations.mariadb | default(false) }}'
+mysql_connector_java_version: 5.1.49
 install_ojdbc8_jar: false
+ojdbc8_jar_version: 21.5.0.0
 payara_user_local: false

--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -152,38 +152,57 @@
     path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext
   register: domainResult
 
-- name: "Force ansible to regather local facts - needed to detect whether mariadb has been installed"
-  setup:
-    filter: ansible_local
-
-- name: 'Download mysql-connector-java jar'
-  get_url:
-    url: https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.25/mysql-connector-java-5.1.25.jar
-    dest: /usr/share/java/mysql-connector-java.jar
-  when: (ansible_os_family == 'Debian' and ansible_distribution_major_version == '20') and (domainResult.stat.exists is defined and domainResult.stat.exists == true and (ansible_local.local.instantiations.mariadb is defined and ansible_local.local.instantiations.mariadb == 'true'))
-
-- name: 'Create symlink to mysql connector library'
+- name: 'Create directory for local jars'
   file:
-    src: /usr/share/java/mysql-connector-java.jar
+    path: /usr/local/share/java
+    state: directory
+    owner: root
+    group: root
+    mode: 0775
+  when: (install_mysql_connector_java | bool) or (install_ojdbc8_jar | bool)
+
+- name: 'Download mysql-connector-java.jar'
+  get_url:
+    url: https://repo1.maven.org/maven2/mysql/mysql-connector-java/{{ mysql_connector_java_version }}/mysql-connector-java-{{ mysql_connector_java_version }}.jar
+    dest: /usr/local/share/java/mysql-connector-java-{{ mysql_connector_java_version }}.jar
+    owner: root
+    group: root
+    mode: 0644
+  when: install_mysql_connector_java | bool
+  notify: payara-handler
+
+- name: 'Create symlink to mysql-connector-java.jar'
+  file:
+    src: /usr/local/share/java/mysql-connector-java-{{ mysql_connector_java_version }}.jar
     path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext/mysql-connector-java.jar
     state: link
     owner: '{{ payara_user }}'
     group: '{{ payara_user }}'
-  when: domainResult.stat.exists is defined and domainResult.stat.exists == true and (ansible_local.local.instantiations.mariadb is defined and ansible_local.local.instantiations.mariadb == 'true')
-  notify: "payara-handler"
+    follow: no
+    force: yes
+  when: install_mysql_connector_java | bool
+  notify: payara-handler
 
-- name: 'Install ojdbc8.jar for Oracle Database access'
-  block:
-    - copy:
-        src: files/ojdbc8.jar
-        dest: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext/ojdbc8.jar
-        owner: "{{ payara_user }}"
-        group: "{{ payara_user }}"
-        mode: 0644
-      when: (domainResult.stat.exists is defined and domainResult.stat.exists == true) and (install_ojdbc8_jar is defined and install_ojdbc8_jar == true) and (ansible_local.local.instantiations.mariadb is not defined or ansible_local.local.instantiations.mariadb == 'false')
-      notify: "payara-handler"
-  rescue:
-    - fail:
-        msg: 'In a browser, go to https://www.oracle.com/uk/database/technologies/appdev/jdbc-downloads.html and, after agreeing to the licence agreement, download ojdbc8.jar. Then move it to the files/ directory.'
+- name: 'Download ojdbc8.jar'
+  get_url:
+    url: https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/{{ ojdbc8_jar_version }}/ojdbc8-{{ ojdbc8_jar_version }}.jar
+    dest: /usr/local/share/java/ojdbc8-{{ ojdbc8_jar_version }}.jar
+    owner: root
+    group: root
+    mode: 0644
+  when: install_ojdbc8_jar | bool
+  notify: payara-handler
+
+- name: 'Create symlink to ojdbc8.jar'
+  file:
+    src: /usr/local/share/java/ojdbc8-{{ ojdbc8_jar_version }}.jar
+    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext/ojdbc8.jar
+    state: link
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
+    follow: no
+    force: yes
+  when: install_ojdbc8_jar | bool
+  notify: payara-handler
 
 - meta: flush_handlers


### PR DESCRIPTION
 - No longer installs the packages that provide `mysql-connector-java.jar`, instead downloads it from maven.
 - Bumps the version of mysql-connector-java to 5.1.49.
 - Downloads `ojdbc8.jar` from maven.

The jars are downloaded to `/usr/local/share/java` and then symlinked from the domain's `lib/ext` directory.

The regathering of facts is moved from the payara task to just after the fact is set in the mariadb installation. This is because the fact is needed before the payara task is run to evaluate the default for `install_mysql_connector_java`.