### PR TITLE
Force Ansible to regather local facts after each component is installed

### DIFF
--- a/roles/authn_anon/tasks/installation.yml
+++ b/roles/authn_anon/tasks/installation.yml
@@ -19,3 +19,7 @@
     value: "{{ authn_anon_version }}"
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise authn_anon installation"
+  setup:
+    filter: ansible_local

--- a/roles/authn_db/tasks/installation.yml
+++ b/roles/authn_db/tasks/installation.yml
@@ -19,3 +19,7 @@
     value: '{{ authn_db_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise authn_db installation"
+  setup:
+    filter: ansible_local

--- a/roles/authn_db/tasks/main.yml
+++ b/roles/authn_db/tasks/main.yml
@@ -51,10 +51,6 @@
   notify:
     - "authn_db-handler"
 
-- name: "Force ansible to regather local facts - needed to detect whether mariadb has been installed"
-  setup:
-    filter: ansible_local
-
 - name: "Configure authn_db setup.properties via templating [MariaDB]"
   template:
     src: templates/mariadb.setup.properties.j2
@@ -117,10 +113,6 @@
 - name: "Setup authn_db if not setup"
   import_tasks: tasks/installation.yml
   when: (ansible_local is not defined) or (ansible_local.local is not defined) or (ansible_local.local.instantiations is not defined) or (ansible_local.local.instantiations.authn_db is not defined) or (ansible_local.local.instantiations.authn_db != 'true')
-
-- name: "Force ansible to regather local facts - needed to detect whether mariadb has been installed"
-  setup:
-    filter: ansible_local
 
 - name: "Setup default database users"
   import_tasks: create_default_users.yml

--- a/roles/authn_ip_clf/tasks/installation.yml
+++ b/roles/authn_ip_clf/tasks/installation.yml
@@ -20,3 +20,7 @@
     value: '{{ authn_ip_clf_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise authn_ip_clf installation"
+  setup:
+    filter: ansible_local

--- a/roles/authn_ldap/tasks/installation.yml
+++ b/roles/authn_ldap/tasks/installation.yml
@@ -19,3 +19,7 @@
     value: "{{ authn_ldap_version }}"
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise authn_ldap installation"
+  setup:
+    filter: ansible_local

--- a/roles/authn_simple/tasks/installation.yml
+++ b/roles/authn_simple/tasks/installation.yml
@@ -20,3 +20,7 @@
     value: '{{ authn_simple_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise authn_simple installation"
+  setup:
+    filter: ansible_local

--- a/roles/authn_uows_clf/tasks/installation.yml
+++ b/roles/authn_uows_clf/tasks/installation.yml
@@ -20,3 +20,7 @@
     value: '{{ authn_uows_clf_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise authn_uows_clf installation"
+  setup:
+    filter: ansible_local

--- a/roles/authn_uows_isis/tasks/installation.yml
+++ b/roles/authn_uows_isis/tasks/installation.yml
@@ -20,3 +20,7 @@
     value: '{{ authn_uows_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise authn_uows_isis installation"
+  setup:
+    filter: ansible_local

--- a/roles/icat_lucene/tasks/installation.yml
+++ b/roles/icat_lucene/tasks/installation.yml
@@ -20,3 +20,7 @@
     value: '{{ icat_lucene_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise icat_lucene installation"
+  setup:
+    filter: ansible_local

--- a/roles/icat_server/tasks/create-setup-properties.yml
+++ b/roles/icat_server/tasks/create-setup-properties.yml
@@ -22,10 +22,6 @@
     group: "{{ payara_user }}"
     mode: 0664
 
-- name: "Force ansible to regather local facts - needed to detect whether mariadb has been installed"
-  setup:
-    filter: ansible_local
-
 - name: "Copy over icat_server setup.properties via templating [MariaDB]"
   template:
     src: templates/mariadb.setup.properties.j2

--- a/roles/icat_server/tasks/installation.yml
+++ b/roles/icat_server/tasks/installation.yml
@@ -23,3 +23,7 @@
     value: '{{ icat_server_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise icat_lucene installation"
+  setup:
+    filter: ansible_local

--- a/roles/icat_server/tasks/main.yml
+++ b/roles/icat_server/tasks/main.yml
@@ -62,10 +62,6 @@
     path: /home/{{ payara_user }}/.bashrc
     line: "export PATH=$PATH:/home/{{ payara_user }}/bin"
 
-- name: "Force ansible to regather local facts - needed to detect what authn plugins have been installed"
-  setup:
-    filter: ansible_local
-
 - name: "Check setup.properties file existence"
   local_action: stat path={{ role_path }}/files/setup.properties
   become: false

--- a/roles/icat_server_dev/tasks/installation.yml
+++ b/roles/icat_server_dev/tasks/installation.yml
@@ -13,3 +13,7 @@
     regexp: '^dev_icat_server'
     insertafter: '^\[instantiations\]$'
     line: 'dev_icat_server=true'
+
+- name: "Force ansible to regather local facts to recognise icat_server_dev installation"
+  setup:
+    filter: ansible_local

--- a/roles/ids_server/tasks/installation.yml
+++ b/roles/ids_server/tasks/installation.yml
@@ -20,3 +20,7 @@
     value: '{{ ids_server_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise ids_server installation"
+  setup:
+    filter: ansible_local

--- a/roles/ids_server/tasks/main.yml
+++ b/roles/ids_server/tasks/main.yml
@@ -59,10 +59,6 @@
     group: "{{ payara_user }}"
     mode: 0775
 
-- name: "Force ansible to regather local facts - needed to detect what authn plugins have been installed"
-  setup:
-    filter: ansible_local
-
 - name: "Check setup.properties file existence"
   local_action: stat path={{ role_path }}/files/setup.properties
   become: false

--- a/roles/ids_storage_file/tasks/installation.yml
+++ b/roles/ids_storage_file/tasks/installation.yml
@@ -20,3 +20,7 @@
     value: '{{ ids_storage_file_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise ids_storage_file installation"
+  setup:
+    filter: ansible_local

--- a/roles/ids_storaged_plugin/tasks/installation.yml
+++ b/roles/ids_storaged_plugin/tasks/installation.yml
@@ -20,3 +20,7 @@
     value: '{{ ids_storaged_plugin_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise ids_storaged_plugin installation"
+  setup:
+    filter: ansible_local

--- a/roles/payara/tasks/installation.yml
+++ b/roles/payara/tasks/installation.yml
@@ -24,3 +24,7 @@
     value: '{{ payara_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise icat_lucene installation"
+  setup:
+    filter: ansible_local

--- a/roles/topcat/tasks/installation.yml
+++ b/roles/topcat/tasks/installation.yml
@@ -20,3 +20,7 @@
     value: '{{ topcat_version }}'
     no_extra_spaces: true
     create: false
+
+- name: "Force ansible to regather local facts to recognise icat_lucene installation"
+  setup:
+    filter: ansible_local

--- a/roles/topcat/tasks/main.yml
+++ b/roles/topcat/tasks/main.yml
@@ -40,10 +40,6 @@
     state: absent
   with_items: "{{ warFilesResult.files }}"
 
-- name: "Force ansible to regather local facts - needed to detect whether mariadb has been installed and which auth plugins are installed"
-  setup:
-    filter: ansible_local
-
 - name: "Create database for topcat"
   mysql_db:
     name: "{{ topcat_database }}"


### PR DESCRIPTION
This PR makes changes regarding forcing the regathering of local facts (as discussed in https://github.com/icatproject-contrib/icat-ansible/pull/79#discussion_r829101568).

I've added the forcing of gathering local facts in `installation.yml` once the local facts have been created each time.