### PR TITLE
Upgrade to Payara 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 hosts
 group_vars/all/vault.yml
+vault_pass.txt

--- a/roles/payara/defaults/main.yml
+++ b/roles/payara/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-payara_version: '4.1.2.181'
+payara_version: '5.2022.1'
 payara_directory: 'payara{{ payara_version }}'
 payara_domain: 'domain1'
 install_mysql_connector_java: '{{ ansible_local.local.instantiations.mariadb | default(false) }}'

--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -149,7 +149,7 @@
 
 - name: 'Check payara domain'
   stat:
-    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext
+    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib
   register: domainResult
 
 - name: 'Create directory for local jars'
@@ -174,7 +174,7 @@
 - name: 'Create symlink to mysql-connector-java.jar'
   file:
     src: /usr/local/share/java/mysql-connector-java-{{ mysql_connector_java_version }}.jar
-    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext/mysql-connector-java.jar
+    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/mysql-connector-java.jar
     state: link
     owner: '{{ payara_user }}'
     group: '{{ payara_user }}'
@@ -196,7 +196,7 @@
 - name: 'Create symlink to ojdbc8.jar'
   file:
     src: /usr/local/share/java/ojdbc8-{{ ojdbc8_jar_version }}.jar
-    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext/ojdbc8.jar
+    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ojdbc8.jar
     state: link
     owner: '{{ payara_user }}'
     group: '{{ payara_user }}'

--- a/roles/topcat/defaults/main.yml
+++ b/roles/topcat/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 
-topcat_version: '2.4.7'
+topcat_version: '2.4.8'


### PR DESCRIPTION
This PR makes the move from Payara 4 to Payara 5. I've used the latest version of Payara 5 (5.2022.1), as used on the DLS ICAT stack. I've changed the JDBC jar files to go to `domains/domain1/lib` instead of `domains/domain1/lib/ext` which was done on Payara 4 ([reasoning for this](https://docs.payara.fish/community/docs/release-notes/release-notes-192.html#_removal_of_system_property)).

I've upgraded TopCAT to 2.4.8 as that version makes [some changes](https://github.com/icatproject/topcat/blob/master/src/site/markdown/release-notes.md#248-26th-mar-2021) to run on Payara 5.

I've also added a file to `.gitignore` which was lying around in my repo. That file is used for CI so I have my own copy so I can use the same command to run the Playbook as the CI does.

I have tested this branch on DataGateway API's CI, which uses ICAT Ansible to spin up an ICAT stack so the API's tests can be run. See https://github.com/ral-facilities/datagateway-api/actions/runs/2035211102