### PR TITLE
Update default topcat version

### DIFF
--- a/roles/topcat/defaults/main.yml
+++ b/roles/topcat/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 
-topcat_version: '2.4.8'
+topcat_version: '2.4.9'


### PR DESCRIPTION
Now that I've released topcat 2.4.9 - this should be the default version installed