### PR TITLE
Add pause at the end of icatdb_minimal_hosts

### DIFF
--- a/icatdb_minimal_hosts.yml
+++ b/icatdb_minimal_hosts.yml
@@ -13,3 +13,7 @@
     - role: authn_anon
     - role: icat_lucene
     - role: icat_server
+  tasks:
+    - name: Pause for 1 minute to allow Payara to start before the handlers run
+      pause:
+        minutes: 1


### PR DESCRIPTION
The last task of the icat_server role is to restart Payara, after which, the handlers that reinstall components run before Payara has fully started. This can be fixed for now by adding a 1-minute pause after the icat_server role.

CI run against this playbook here: https://github.com/icatproject-contrib/icat-ansible/actions/runs/6195858670