### PR TITLE
Support for icat.lucene >= 3.0.0 & icat.server >= 6.1.0

### DIFF
--- a/roles/icat_lucene/templates/run.properties.j2
+++ b/roles/icat_lucene/templates/run.properties.j2
@@ -4,3 +4,8 @@
 directory = /home/{{ payara_user }}/{{ icat_lucene_data_dir }}
 commitSeconds = 5
 ip = 127.0.0.1/32 0:0:0:0:0:0:0:1/128 10.0.0.1/8 {{ ansible_default_ipv4.address }}/32
+{% if icat_lucene_version is version('3.0.0', '>=') %}
+maxShardSize   = 2147483648
+aggregateFiles = false
+facetFields    = datafileFormat.name instrument.name sample.type.name stringValue technique.name type.name
+{% endif %}

--- a/roles/icat_server/templates/run.properties.j2
+++ b/roles/icat_server/templates/run.properties.j2
@@ -74,21 +74,33 @@ notification.Datafile = CU
 # Call logging setup
 log.list = SESSION WRITE READ INFO
 
-# Lucene
 {% if ansible_local.local.instantiations.icat_lucene is defined and ansible_local.local.instantiations.icat_lucene == 'true' %}
+{% if icat_server_version is version('6.1.0', '>=') %}
+# Search Engine
+# LUCENE, OPENSEARCH and ELASTICSEARCH engines are supported, however the latter two are considered experimental
+search.engine = LUCENE
+search.urls = {{ lucene_url }} 
+search.populateBlockSize = {{ icat_server_lucene_populateBlockSize }}
+# Recommend setting search.searchBlockSize equal to maxIdsInQuery, so that all results can be authorised at once
+# If search.searchBlockSize > maxIdsInQuery, then multiple auth checks may be needed for a single search
+# The optimal value depends on how likely a user's auth request fails: larger values are more efficient when rejection is more likely
+search.searchBlockSize = 1000
+search.directory = /home/{{ payara_user }}/{{ icat_lucene_data_dir }}
+search.backlogHandlerIntervalSeconds = 60
+search.enqueuedRequestIntervalSeconds = 5
+search.aggregateFilesIntervalSeconds = 3600
+search.maxSearchTimeSeconds = 5
+# The entities to index with the search engine. Leave uncommented to index everything
+!search.entitiesToIndex = Datafile Dataset Investigation InvestigationUser DatafileParameter DatasetParameter InvestigationParameter Sample
+{% else %}
+# Lucene
 lucene.url = {{ lucene_url }}
 lucene.populateBlockSize = {{ icat_server_lucene_populateBlockSize }}
 lucene.directory = /home/{{ payara_user }}/{{ icat_lucene_data_dir }}
 lucene.backlogHandlerIntervalSeconds = 60
 lucene.enqueuedRequestIntervalSeconds = 5
 lucene.entitiesToIndex = Dataset Investigation InvestigationUser DatasetParameter InvestigationParameter Sample
-{% else %}
-!lucene.url = https://localhost:8181
-!lucene.populateBlockSize = 10000
-!lucene.directory = /home/{{ payara_user }}/data/lucene
-!lucene.backlogHandlerIntervalSeconds = 60
-!lucene.enqueuedRequestIntervalSeconds = 5
-!lucene.entitiesToIndex = Dataset Investigation InvestigationUser DatasetParameter InvestigationParameter Sample
+{% endif %}
 {% endif %}
 
 # List members of cluster


### PR DESCRIPTION
Patrick's new search stuff has different properties that need to be configured, so use a version check to determine whether to template in the new settings or the old ones