### PR TITLE
Correct URL to download `setup-glassfish.py`

### DIFF
--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -92,7 +92,7 @@
 
 - name: 'Download payara setup script'
   get_url:
-    url: https://icatproject.org/misc/scripts/setup-glassfish.py
+    url: https://raw.githubusercontent.com/icatproject/icat.utils/master/src/main/scripts/setup-glassfish.py
     dest: /home/{{ payara_user }}/scripts
     owner: '{{ payara_user }}'
     group: '{{ payara_user_group }}'


### PR DESCRIPTION
Small PR to fix the URL to fix the CI on DataGateway so ICAT Ansible isn't broken