### PR TITLE
Upgrade ansible version & use Ubuntu 24 runner

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run_all_roles:
     name: Run all ICAT Ansible roles
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         java_version: [11, 17, 21]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.10.*
+ansible==9.*


### PR DESCRIPTION
In order to be able to use Ubuntu 24 runner in DataGateway - we need to bump the ansible version. Figured I might as well also upgrade the CI Ubuntu version as well for testing

NOTE: I didn't test any ansible versions higher than 9 - 9 was just the minimum that works with Python 3.12. Didn't want to bump higher in case of any further breaking changes